### PR TITLE
Adds min_size config option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ### Upcoming
 
+* Adds min_size config option to enforce minimum UXID sizes (useful for test environments)
+
 ### 2.2.0 / 2025-09-12
 
 * Adds UXID.Decoder module with full pipeline processing and uppercase/lowercase support

--- a/README.md
+++ b/README.md
@@ -53,6 +53,40 @@ defmodule YourApp.User do
 end
 ```
 
+### Configuration
+
+#### Case
+
+The `:case` config option controls the default case for generated UXIDs. By default, UXIDs are lowercase (`:lower`), but you can configure uppercase (`:upper`) globally or per-call.
+
+```elixir
+# config/config.exs
+config :uxid, case: :upper
+
+# All generated UXIDs will be uppercase by default
+UXID.generate!()
+# => "01EMDGJF0DQXQJ8FM78XE97Y3H"
+
+# Override per-call if needed
+UXID.generate!(case: :lower)
+# => "01emdgjf0dqxqj8fm78xe97y3h"
+```
+
+#### Minimum Size
+
+The `:min_size` config option enforces a minimum UXID size regardless of what size is requested. This is useful in test environments where many IDs are generated rapidly, as smaller sizes have limited randomness that can cause duplicate key violations.
+
+```elixir
+# config/test.exs
+config :uxid, min_size: :medium
+
+# In application code - requests :small but gets :medium in test env
+UXID.generate!(prefix: "usr", size: :small)
+# => Returns 18 character UXID instead of 14
+```
+
+When configured, any requested size smaller than `:min_size` will be automatically upgraded. Larger sizes are not affected.
+
 ## Installation
 
 The package can be installed by adding `uxid` to your list of dependencies in `mix.exs`:

--- a/lib/uxid.ex
+++ b/lib/uxid.ex
@@ -78,6 +78,12 @@ defmodule UXID do
 
   def encode_case(), do: Application.get_env(:uxid, :case, :lower)
 
+  @doc """
+  Returns the minimum size configuration.
+  When set, any requested size smaller than this will be upgraded.
+  """
+  def min_size(), do: Application.get_env(:uxid, :min_size, nil)
+
   @spec decode(String.t()) :: {:ok, %Codec{}}
   @doc """
   Decodes a UXID string and returns a Codec struct with extracted components.


### PR DESCRIPTION
This allows specific environments (like test) to enforce maximum UXID sizes.