### PR TITLE
Adds default_delimiter config accessor

### DIFF
--- a/lib/uxid.ex
+++ b/lib/uxid.ex
@@ -81,6 +81,13 @@ defmodule UXID do
   def encode_case(), do: Application.get_env(:uxid, :case, :lower)
 
   @doc """
+  Returns the delimiter used to separate a prefix from the encoded body.
+  Defaults to `"_"` and can be overridden globally with the `:delimiter`
+  application env, or per-call/per-field with the `:delimiter` option.
+  """
+  def default_delimiter(), do: Application.get_env(:uxid, :delimiter, "_")
+
+  @doc """
   Returns the minimum size configuration.
   When set, any requested size smaller than this will be upgraded.
   """

--- a/lib/uxid/decoder.ex
+++ b/lib/uxid/decoder.ex
@@ -6,8 +6,6 @@ defmodule UXID.Decoder do
 
   alias UXID.Codec
 
-  @delimiter "_"
-
   @spec process(Codec.t()) :: {:ok, Codec.t()} | {:error, String.t()}
   def process(%Codec{} = struct) do
     decoded =
@@ -34,15 +32,17 @@ defmodule UXID.Decoder do
   end
 
   defp split_uxid_string(uxid_string) do
+    delimiter = UXID.default_delimiter()
+
     uxid_string
-    |> String.split(@delimiter)
+    |> String.split(delimiter)
     |> case do
       [encoded] ->
         %{prefix: nil, encoded: encoded}
 
       split ->
         {encoded, prefix_parts} = List.pop_at(split, -1)
-        %{prefix: Enum.join(prefix_parts, @delimiter), encoded: encoded}
+        %{prefix: Enum.join(prefix_parts, delimiter), encoded: encoded}
     end
   end
 

--- a/lib/uxid/encoder.ex
+++ b/lib/uxid/encoder.ex
@@ -6,7 +6,6 @@ defmodule UXID.Encoder do
 
   alias UXID.Codec
 
-  @default_delimiter "_"
   @default_rand_size 10
 
   @size_order [:xs, :xsmall, :s, :small, :m, :medium, :l, :large, :xl, :xlarge]
@@ -144,7 +143,7 @@ defmodule UXID.Encoder do
   defp ensure_case(uxid), do: uxid
 
   defp ensure_delimiter(%Codec{delimiter: nil} = uxid),
-    do: %{uxid | delimiter: @default_delimiter}
+    do: %{uxid | delimiter: UXID.default_delimiter()}
 
   defp ensure_delimiter(uxid), do: uxid
 


### PR DESCRIPTION
Introduces UXID.default_delimiter/0 which reads the :delimiter application env (defaulting to "_"), mirroring the existing encode_case/0 accessor.

The encoder and decoder now defer to this accessor instead of each carrying their own hardcoded "_" module attribute, giving the prefix delimiter a single, globally configurable source of truth.