### PR TITLE
Adds opt-in strict validation for UXID casting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ### Upcoming
 
+* Adds `UXID.valid?/2` for structural validation of a UXID string (optional `:prefix` and `:delimiter`)
+* Adds opt-in strict casting for the Ecto type via `validate: true` on a field:
+  - Accepts a well-formed UXID carrying the field's configured `:prefix`, or a legacy bare UUID string
+  - Rejects malformed values (empty, wrong prefix, non–Base32) with `:error`
+  - UUID coexistence is on by default (eases `uuid` → `text` column migrations); disable with `allow_uuid: false`
+  - Default casting is unchanged (any binary passes) when `validate` is not set — fully backwards compatible
+
 ### 2.3.0 / 2026-01-16
 
 * Adds min_size config option to enforce minimum UXID sizes (useful for test environments)

--- a/README.md
+++ b/README.md
@@ -56,6 +56,37 @@ defmodule YourApp.User do
 end
 ```
 
+### Validation
+
+By default `cast/2` accepts any binary unchanged, which is ideal while a schema
+still holds a mix of legacy identifiers. A field can opt in to strict validation
+with `validate: true`, in which case a value must be either a structurally valid
+UXID carrying the field's configured `:prefix`, or a legacy bare UUID string
+(canonical 36-character form). Anything else — an empty string, the wrong prefix,
+non–Base32 characters — casts to `:error`.
+
+```elixir
+@primary_key {:id, UXID, autogenerate: true, prefix: "org", size: :medium, validate: true}
+schema "organizations" do
+  field :owner_org_id, UXID, prefix: "org", validate: true
+end
+```
+
+UUID coexistence is on by default so a table can migrate its column type from
+`uuid` to `text` without rewriting existing rows. Turn it off with
+`allow_uuid: false` once a table holds only UXIDs.
+
+You can also validate a string directly, without Ecto:
+
+```elixir
+UXID.valid?("org_01emdgjf0dqxqj8fm78xe97y3h")                 # => true
+UXID.valid?("org_01emdgjf0dqxqj8fm78xe97y3h", prefix: "usr")  # => false
+UXID.valid?("not-a-uxid")                                     # => false
+```
+
+`valid?/2` checks *structure* (prefix + Crockford Base32 body), not authenticity,
+and deliberately does not accept bare UUIDs — that coexistence lives in `cast/2`.
+
 ### Configuration
 
 #### Case

--- a/lib/uxid.ex
+++ b/lib/uxid.ex
@@ -34,6 +34,18 @@ defmodule UXID do
   alias UXID.{Codec, Encoder}
   alias UXID.Decoder
 
+  # Crockford Base32 alphabet (excludes I, L, O, U), in both cases. A UXID body
+  # is made up entirely of these characters.
+  @crockford_body ~r/\A[0-9ABCDEFGHJKMNPQRSTVWXYZabcdefghjkmnpqrstvwxyz]+\z/
+
+  # Canonical 36-character hyphenated UUID, any case. Identifiers that predate
+  # UXID adoption are stored as UUID strings and must remain castable.
+  @uuid_format ~r/\A[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\z/
+
+  # Shortest legitimate encoded body: a compact 40-bit timestamp with no
+  # randomness encodes to 8 characters.
+  @min_body_length 8
+
   @spec generate(opts :: options()) :: {:ok, __MODULE__.t()}
   @doc """
   Returns an encoded UXID string along with response status.
@@ -107,6 +119,69 @@ defmodule UXID do
     |> Decoder.process()
   end
 
+  @spec valid?(term(), keyword()) :: boolean()
+  @doc """
+  Returns `true` if the given value is a structurally valid UXID.
+
+  A valid UXID is a binary made up of an optional prefix, the delimiter, and a
+  Crockford Base32 body of at least #{@min_body_length} characters. This checks
+  *structure*, not authenticity: it cannot distinguish a generated UXID from an
+  arbitrary Base32 string of the same shape, and it deliberately does **not**
+  accept a bare UUID (see `cast/2`'s `:validate` mode for UUID coexistence).
+
+  ## Options
+
+    * `:prefix` - when present, the value must carry exactly this prefix. When
+      omitted, any prefix (or none) is accepted.
+    * `:delimiter` - the prefix delimiter (defaults to the configured
+      delimiter, see `default_delimiter/0`).
+
+  ## Examples
+
+      iex> UXID.valid?("cus_01emdgjf0dqxqj8fm78xe97y3h")
+      true
+
+      iex> UXID.valid?("cus_01emdgjf0dqxqj8fm78xe97y3h", prefix: "cus")
+      true
+
+      iex> UXID.valid?("cus_01emdgjf0dqxqj8fm78xe97y3h", prefix: "usr")
+      false
+
+      iex> UXID.valid?("nope!")
+      false
+  """
+  def valid?(term, opts \\ [])
+
+  def valid?(term, opts) when is_binary(term) do
+    delimiter = Keyword.get(opts, :delimiter, default_delimiter())
+    {prefix, body} = split_prefix(term, delimiter)
+
+    body_valid?(body) and prefix_ok?(prefix, Keyword.get(opts, :prefix))
+  end
+
+  def valid?(_term, _opts), do: false
+
+  defp body_valid?(body) do
+    String.length(body) >= @min_body_length and Regex.match?(@crockford_body, body)
+  end
+
+  defp prefix_ok?(_actual, nil), do: true
+  defp prefix_ok?(actual, expected), do: actual == expected
+
+  defp split_prefix(string, delimiter) do
+    case String.split(string, delimiter) do
+      [body] ->
+        {nil, body}
+
+      parts ->
+        {body, prefix_parts} = List.pop_at(parts, -1)
+        {Enum.join(prefix_parts, delimiter), body}
+    end
+  end
+
+  defp uuid_string?(term) when is_binary(term), do: Regex.match?(@uuid_format, term)
+  defp uuid_string?(_term), do: false
+
   # Define additional functions for custom Ecto type if Ecto is loaded
   if Code.ensure_loaded?(Ecto.ParameterizedType) do
     @behaviour Ecto.ParameterizedType
@@ -147,14 +222,40 @@ defmodule UXID do
 
     @doc """
     Casts the given input to the UXID ParameterizedType with the given parameters.
+
+    By default any binary is accepted unchanged (backwards compatible). When the
+    field opts in with `validate: true`, the value must be either a structurally
+    valid UXID carrying the field's configured `:prefix` (see `valid?/2`) or a
+    legacy bare UUID string; anything else casts to `:error`. UUID coexistence
+    can be turned off with `allow_uuid: false`.
+
+        field :owner_org_id, UXID, prefix: "org", validate: true
     """
-    def cast(data, _params) do
-      cast_binary(data)
+    def cast(data, params) do
+      if Map.get(params, :validate, false) do
+        cast_strict(data, params)
+      else
+        cast_binary(data)
+      end
     end
 
     defp cast_binary(nil), do: {:ok, nil}
     defp cast_binary(term) when is_binary(term), do: {:ok, term}
     defp cast_binary(_), do: :error
+
+    defp cast_strict(nil, _params), do: {:ok, nil}
+
+    defp cast_strict(term, params) when is_binary(term) do
+      opts = [prefix: Map.get(params, :prefix), delimiter: Map.get(params, :delimiter, default_delimiter())]
+
+      cond do
+        valid?(term, opts) -> {:ok, term}
+        Map.get(params, :allow_uuid, true) and uuid_string?(term) -> {:ok, term}
+        true -> :error
+      end
+    end
+
+    defp cast_strict(_term, _params), do: :error
 
     @doc """
     Loads the given term into a UXID.

--- a/test/uxid/ecto_type_test.exs
+++ b/test/uxid/ecto_type_test.exs
@@ -34,6 +34,54 @@ defmodule UXID.EctoTypeTest do
       assert :error = UXID.cast(1, %{})
       assert :error = UXID.cast(:atom, %{})
     end
+
+    test "without :validate, any binary passes through unchanged" do
+      assert {:ok, "anything at all"} = UXID.cast("anything at all", %{prefix: "org"})
+    end
+  end
+
+  describe "cast/2 in strict :validate mode" do
+    @strict %{validate: true, prefix: "org"}
+
+    test "accepts a well-formed UXID carrying the configured prefix" do
+      uxid = UXID.generate!(prefix: "org")
+      assert {:ok, ^uxid} = UXID.cast(uxid, @strict)
+    end
+
+    test "accepts a legacy bare UUID string (coexistence)" do
+      uuid = "550e8400-e29b-41d4-a716-446655440000"
+      assert {:ok, ^uuid} = UXID.cast(uuid, @strict)
+    end
+
+    test "accepts nil" do
+      assert {:ok, nil} = UXID.cast(nil, @strict)
+    end
+
+    test "rejects a value carrying the wrong prefix" do
+      wrong = UXID.generate!(prefix: "usr")
+      assert :error = UXID.cast(wrong, @strict)
+    end
+
+    test "rejects malformed strings" do
+      assert :error = UXID.cast("", @strict)
+      assert :error = UXID.cast("org_", @strict)
+      assert :error = UXID.cast("org_!!!bad", @strict)
+      assert :error = UXID.cast("not-an-id", @strict)
+    end
+
+    test "rejects non-binary values" do
+      assert :error = UXID.cast(123, @strict)
+    end
+
+    test "allow_uuid: false rejects legacy UUIDs" do
+      uuid = "550e8400-e29b-41d4-a716-446655440000"
+      assert :error = UXID.cast(uuid, %{validate: true, prefix: "org", allow_uuid: false})
+    end
+
+    test "with :validate but no configured prefix, any well-formed UXID passes" do
+      uxid = UXID.generate!(prefix: "anything")
+      assert {:ok, ^uxid} = UXID.cast(uxid, %{validate: true})
+    end
   end
 
   describe "type/1" do

--- a/test/uxid_test.exs
+++ b/test/uxid_test.exs
@@ -54,4 +54,34 @@ defmodule UXIDTest do
       assert :error = UXID.cast(:atom, %{})
     end
   end
+
+  describe "valid?/2" do
+    test "accepts generated UXIDs, with and without a prefix" do
+      assert UXID.valid?(UXID.generate!())
+      assert UXID.valid?(UXID.generate!(prefix: "cus"))
+      assert UXID.valid?(UXID.generate!(prefix: "cus"), prefix: "cus")
+    end
+
+    test "enforces a required prefix" do
+      refute UXID.valid?(UXID.generate!(prefix: "cus"), prefix: "usr")
+      refute UXID.valid?(UXID.generate!(), prefix: "usr")
+    end
+
+    test "rejects non-Crockford, too-short, and non-binary values" do
+      refute UXID.valid?("")
+      refute UXID.valid?("short")
+      refute UXID.valid?("cus_!!!")
+      refute UXID.valid?(nil)
+      refute UXID.valid?(123)
+    end
+
+    test "does not treat a bare UUID as a valid UXID" do
+      refute UXID.valid?("550e8400-e29b-41d4-a716-446655440000")
+    end
+
+    test "honors a custom delimiter" do
+      id = UXID.generate!(prefix: "cus", delimiter: "-")
+      assert UXID.valid?(id, prefix: "cus", delimiter: "-")
+    end
+  end
 end


### PR DESCRIPTION
Adds UXID.valid?/2 for structural validation of a UXID string (optional :prefix and :delimiter), checking the prefix and a Crockford Base32 body.

Adds opt-in strict casting for the Ecto type via validate: true on a field:

- Accepts a well-formed UXID carrying the field's configured :prefix, or a legacy bare UUID string
- Rejects malformed values (empty, wrong prefix, non-Base32) with :error
- UUID coexistence is on by default to ease uuid -> text column migrations; disable with allow_uuid: false
- Default casting is unchanged (any binary passes) when validate is not set, so this is fully backwards compatible

The validation and casting paths honor the configured delimiter via default_delimiter/0.