### PR TITLE
Advances monotonic counter by a random step, not +1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 * Adds opt-in monotonic generation via the `monotonic` option (per-call/per-field) or `config :uxid, :monotonic` global policy:
   - Accepts `true`/`false`, or a list of sizes (alias-aware, e.g. `[:small]` matches both `:small` and `:s`)
-  - Within a millisecond the random field is seeded once then incremented by 1, guaranteeing uniqueness and K-sortability for a burst — process-local, `async: true` safe, no GenServer/ETS
-  - Per-call option takes precedence over the global policy; off by default (consecutive IDs become guessable, weakening enumeration resistance)
+  - Within a millisecond the random field is seeded once then advanced by a random positive step (uniform over `[1, 2^(bits/2)]`, drawn from the CSPRNG), guaranteeing uniqueness and K-sortability for a burst — process-local, `async: true` safe, no GenServer/ETS
+  - Per-call option takes precedence over the global policy; off by default (consecutive IDs stay in a bounded window — a mitigation, not cryptographic unpredictability — weakening enumeration resistance)
   - `:xs`/`:xsmall` auto-enable `compact_time` so there is a field to increment; explicit `compact_time: false` on those sizes with monotonic on raises
   - Wire format is byte-identical to a random UXID — no decoder changes
 

--- a/README.md
+++ b/README.md
@@ -181,11 +181,18 @@ Standard UXIDs draw fresh randomness for every ID, so collision risk within a
 single millisecond is a birthday problem — for small sizes (`:xsmall` has 0
 random bits, `:small` has 16) a burst of same-millisecond IDs can collide.
 Monotonic mode fixes this the way the ULID monotonic spec does: within a
-millisecond it seeds the random field once from the CSPRNG, then **increments by
-1** for each subsequent ID. That turns "birthday collision among N draws" into
-"guaranteed distinct for up to 2^bits draws," and because the field is encoded
-big-endian, incrementing also sorts strictly after — K-sortability is preserved
-at every size.
+millisecond it seeds the random field once from the CSPRNG, then advances it by a
+**random positive step** for each subsequent ID. That turns "birthday collision
+among N draws" into "guaranteed distinct until the field overflows," and because
+the field is encoded big-endian, a strictly increasing counter also sorts
+strictly after — K-sortability is preserved at every size.
+
+The step is uniform over `[1, 2^(bits/2)]` (the square root of the field space,
+auto-derived from the size — no configuration). Stepping by a random amount
+instead of exactly `+1` means an attacker who sees `…0004` can no longer guess
+`…0005`: single-shot guess cost rises from certainty to `~1/2^(bits/2)` (1/256 at
+`:small`, ~1/10⁶ at `:medium`), while still leaving ample same-ms burst headroom
+before overflow (~512 IDs/ms at `:small`, ~2M at `:medium`).
 
 ```elixir
 # Per-call: on for all sizes
@@ -216,10 +223,13 @@ process*. State lives in the process dictionary (keyed by prefix and field size)
 process gets an independent random starting point per millisecond, so
 cross-process collisions fall back to a birthday probability on the field size.
 
-**Tradeoff (why it is opt-in):** consecutive burst IDs differ by `+1` in the low
-bits — i.e. guessable. That weakens the "secure against enumeration attacks"
-property, so monotonic must be a conscious per-resource choice and is never a
-silent default.
+**Tradeoff (why it is opt-in):** the random step is a *mitigation, not
+cryptographic unpredictability*. It removes trivial `+1` enumeration, but an
+attacker who observes two consecutive same-ms IDs learns the actual gap, and
+values still lie in a bounded window ahead. Low-entropy sizes stay low-entropy,
+so monotonic must be a conscious per-resource choice and is never a silent
+default — don't use `:small`/`:medium` monotonic IDs as externally-enumerable,
+security-sensitive identifiers; prefer `:large`/`:xl` (and non-monotonic) there.
 
 **`:xs`/`:xsmall` note:** a standard `:xs` has 0 random bits — nothing to
 increment — so when monotonic is active `compact_time` is enabled automatically

--- a/lib/uxid.ex
+++ b/lib/uxid.ex
@@ -124,9 +124,10 @@ defmodule UXID do
 
   When active, the random field is treated as a big-endian counter: the first
   ID in a millisecond is seeded from the CSPRNG and each subsequent same-ms ID
-  increments by 1 (per process, per prefix). This guarantees uniqueness and
-  K-sortability within a burst at the cost of making consecutive IDs guessable,
-  which is why it is off by default and opt-in per resource.
+  advances it by a random positive step (per process, per prefix). This
+  guarantees uniqueness and K-sortability within a burst while keeping
+  consecutive IDs within a bounded window ahead — a mitigation, not cryptographic
+  unpredictability — which is why it is off by default and opt-in per resource.
 
   Accepts `true`/`false`, or a list of sizes (alias-aware, e.g. `[:small]`
   matches both `:small` and `:s`). Overridable per-call/per-field with the

--- a/lib/uxid/monotonic.ex
+++ b/lib/uxid/monotonic.ex
@@ -8,10 +8,20 @@ defmodule UXID.Monotonic do
 
   The random field is treated as one big-endian unsigned integer. The first ID
   in a given millisecond seeds it with full CSPRNG bytes; each subsequent ID in
-  the same millisecond increments by 1. Because the encoding is big-endian and
-  the Crockford alphabet is ASCII-monotonic, integer order equals encoded
-  lexical order, so incrementing also sorts after — preserving K-sortability
-  within the millisecond.
+  the same millisecond advances it by a random positive step drawn from the
+  CSPRNG. Because the step is always `>= 1` the sequence is strictly increasing,
+  so IDs stay unique and — since the encoding is big-endian and the Crockford
+  alphabet is ASCII-monotonic — integer order equals encoded lexical order,
+  preserving K-sortability within the millisecond.
+
+  The step is uniform over `[1, 2^(bits/2)]` where `bits` is the field width, so
+  the next value is spread across a window of size `~2^(bits/2)` instead of being
+  exactly `+1`. This is a *mitigation, not cryptographic unpredictability*: it
+  removes trivial `…0004` → `…0005` enumeration and raises single-shot guess cost
+  from certainty to `~1/2^(bits/2)`, but consecutive values still lie in a bounded
+  window ahead. Low-entropy sizes (`:small` = 16 bits) remain low-entropy — don't
+  use small/medium monotonic IDs as externally-enumerable, security-sensitive
+  identifiers.
   """
   import Bitwise
 
@@ -27,8 +37,9 @@ defmodule UXID.Monotonic do
 
     case Process.get(key) do
       {last_time, last_int} when time <= last_time ->
-        # same ms, or clock moved backward: keep last_time, increment
-        int = last_int + 1
+        # same ms, or clock moved backward: keep last_time, advance by a
+        # random positive step (may overshoot max, hence the < guard below)
+        int = last_int + step(rand_size)
 
         if int < max do
           store(key, last_time, int, rand_size)
@@ -51,6 +62,18 @@ defmodule UXID.Monotonic do
   def reset(prefix, rand_size), do: Process.delete({__MODULE__, prefix, rand_size})
 
   defp seed(rand_size), do: :crypto.strong_rand_bytes(rand_size) |> :binary.decode_unsigned()
+
+  # Random increment for a same-millisecond ID: uniform over [1, 2^step_bits],
+  # where step_bits is half the field width (the sqrt-of-the-field-space rule).
+  # step_bits is a whole number of random bits masked from CSPRNG bytes, so the
+  # draw is unbiased (no modulo bias). A step >= 1 preserves strict monotonicity.
+  defp step(rand_size) do
+    step_bits = div(rand_size * 8, 2)
+    nbytes = max(1, div(step_bits + 7, 8))
+    mask = (1 <<< step_bits) - 1
+
+    (:crypto.strong_rand_bytes(nbytes) |> :binary.decode_unsigned() &&& mask) + 1
+  end
 
   defp store(key, time, int, rand_size) do
     Process.put(key, {time, int})

--- a/test/uxid/monotonic_test.exs
+++ b/test/uxid/monotonic_test.exs
@@ -1,6 +1,8 @@
 defmodule UXID.MonotonicTest do
   use ExUnit.Case, async: true
 
+  import Bitwise
+
   alias UXID.Monotonic
 
   describe "next/3" do
@@ -10,11 +12,16 @@ defmodule UXID.MonotonicTest do
       assert byte_size(rand) == 2
     end
 
-    test "increments by 1 within the same millisecond" do
+    test "advances by a positive step within the same millisecond" do
       {_t, r1} = Monotonic.next("evt", 3, 5000)
       {_t, r2} = Monotonic.next("evt", 3, 5000)
 
-      assert :binary.decode_unsigned(r2) == :binary.decode_unsigned(r1) + 1
+      # Random step is in [1, 2^12] for a 3-byte field: strictly greater, and
+      # within the forward step window (never a full reseed within the ms).
+      u1 = :binary.decode_unsigned(r1)
+      u2 = :binary.decode_unsigned(r2)
+      assert u2 > u1
+      assert (u2 - u1) in 1..(1 <<< 12)
       assert r2 > r1
     end
 
@@ -29,36 +36,55 @@ defmodule UXID.MonotonicTest do
       assert rands == Enum.sort(rands)
     end
 
-    test "reseeds (does not just +1) when the millisecond advances" do
+    test "steps vary and stay within [1, 2^(bits/2)] (not a constant +1)" do
+      # 2-byte field: step_bits = 8, so gaps lie in [1, 256]. A constant +1 would
+      # be the old guessable behavior; over 50 draws at least one gap must exceed 1.
+      ints =
+        for _ <- 1..50 do
+          {_t, r} = Monotonic.next("vary", 2, 90_000)
+          :binary.decode_unsigned(r)
+        end
+
+      gaps = Enum.zip(ints, tl(ints)) |> Enum.map(fn {a, b} -> b - a end)
+
+      assert Enum.all?(gaps, &(&1 in 1..256))
+      assert Enum.any?(gaps, &(&1 > 1))
+    end
+
+    test "reseeds (does not continue the step sequence) when the millisecond advances" do
       {_t, r1} = Monotonic.next("seed", 4, 10_000)
       {_t, r2} = Monotonic.next("seed", 4, 10_001)
 
-      # A fresh 32-bit seed landing exactly on r1 + 1 is a 1-in-2^32 event.
-      refute :binary.decode_unsigned(r2) == :binary.decode_unsigned(r1) + 1
+      u1 = :binary.decode_unsigned(r1)
+      u2 = :binary.decode_unsigned(r2)
+
+      # Continuing would land in the forward step window (u1, u1 + 2^16]. A fresh
+      # 32-bit seed doing so is a ~1-in-2^16 event, so treat it as a reseed.
+      refute u2 in (u1 + 1)..(u1 + (1 <<< 16))
     end
 
-    test "clock moving backward keeps the last time and still increments" do
+    test "clock moving backward keeps the last time and still advances" do
       {t1, r1} = Monotonic.next("back", 3, 20_000)
       {t2, r2} = Monotonic.next("back", 3, 19_995)
 
       assert t2 == t1
-      assert :binary.decode_unsigned(r2) == :binary.decode_unsigned(r1) + 1
+      assert :binary.decode_unsigned(r2) > :binary.decode_unsigned(r1)
     end
 
     test "overflow within a ms spins the time forward and reseeds" do
-      # 1-byte field = 256 values (0..255).
+      # 1-byte field = 256 values; random steps of [1, 16] exhaust it within a
+      # few dozen draws. Draw until the time bumps forward.
       time = 30_000
-      {^time, first} = Monotonic.next("of", 1, time)
-      start = :binary.decode_unsigned(first)
 
-      # Exhaust the remaining capacity of the field within this ms.
-      for _ <- 1..(255 - start) do
-        {^time, _} = Monotonic.next("of", 1, time)
-      end
+      bumped =
+        Enum.reduce_while(1..1000, nil, fn _, _ ->
+          case Monotonic.next("of", 1, time) do
+            {^time, _} -> {:cont, nil}
+            {t, _} when t > time -> {:halt, t}
+          end
+        end)
 
-      # The next call overflows: time bumps forward, field reseeds.
-      {bumped_time, _reseeded} = Monotonic.next("of", 1, time)
-      assert bumped_time == time + 1
+      assert bumped == time + 1
     end
 
     test "distinct prefixes maintain independent sequences" do
@@ -66,8 +92,8 @@ defmodule UXID.MonotonicTest do
       {_t, b} = Monotonic.next("b", 2, 40_000)
       {_t, a2} = Monotonic.next("a", 2, 40_000)
 
-      assert :binary.decode_unsigned(a2) == :binary.decode_unsigned(a) + 1
-      # b's sequence is unaffected by a's increments.
+      assert :binary.decode_unsigned(a2) > :binary.decode_unsigned(a)
+      # b's sequence is unaffected by a's advances.
       assert byte_size(b) == 2
     end
 
@@ -82,7 +108,7 @@ defmodule UXID.MonotonicTest do
     test "nil prefix is a valid, independent sequence" do
       {_t, r1} = Monotonic.next(nil, 2, 60_000)
       {_t, r2} = Monotonic.next(nil, 2, 60_000)
-      assert :binary.decode_unsigned(r2) == :binary.decode_unsigned(r1) + 1
+      assert :binary.decode_unsigned(r2) > :binary.decode_unsigned(r1)
     end
   end
 
@@ -116,8 +142,10 @@ defmodule UXID.MonotonicTest do
           1000 -> flunk("child process did not respond")
         end
 
-      # The child starts its own sequence — it is not r1 + 1.
-      refute :binary.decode_unsigned(child) == :binary.decode_unsigned(r1) + 1
+      # The child starts its own sequence (a fresh seed), not a continuation of
+      # the parent's — so it does not land in the parent's forward step window.
+      u1 = :binary.decode_unsigned(r1)
+      refute :binary.decode_unsigned(child) in (u1 + 1)..(u1 + (1 <<< 8))
     end
   end
 
@@ -127,6 +155,17 @@ defmodule UXID.MonotonicTest do
   defp rand_int(opts) do
     {:ok, codec} = UXID.new(opts)
     :binary.decode_unsigned(codec.rand)
+  end
+
+  # Decides whether `opts` yields a monotonic sequence. A monotonic same-ms burst
+  # is always strictly increasing and unique; a random one is sorted only by
+  # chance (~1/n!). A 20-draw burst makes false positives ~1/20! — effectively
+  # zero — so this reliably distinguishes random-step monotonic from pure random,
+  # which a single `> ` pair (~50%) cannot. All draws share one ms; the field
+  # sizes here never overflow in 20 steps, so the raw rand ints stay ordered.
+  defp monotonic?(opts) do
+    ints = for _ <- 1..20, do: rand_int(opts)
+    ints == Enum.sort(ints) and length(Enum.uniq(ints)) == 20
   end
 
   describe "monotonic generation via generate!/1" do
@@ -149,12 +188,13 @@ defmodule UXID.MonotonicTest do
       assert ids == Enum.sort(ids)
     end
 
-    test "a new millisecond reseeds instead of continuing the +1 sequence" do
+    test "a new millisecond reseeds instead of continuing the step sequence" do
       first = rand_int(size: :medium, time: 1_700_000_100_000, monotonic: true)
       later = rand_int(size: :medium, time: 1_700_000_100_001, monotonic: true)
 
-      # A fresh 40-bit seed landing exactly on first + 1 is a 1-in-2^40 event.
-      refute later == first + 1
+      # Continuing would land in the forward step window (first, first + 2^20]. A
+      # fresh 40-bit seed doing so is a ~1-in-2^20 event, so treat it as a reseed.
+      refute later in (first + 1)..(first + (1 <<< 20))
     end
 
     test "clock moving backward still increases and never emits a smaller time" do
@@ -165,11 +205,8 @@ defmodule UXID.MonotonicTest do
       assert c2.string > c1.string
     end
 
-    test "non-monotonic generation is unaffected (no exact +1 relationship)" do
-      t = 1_700_000_300_000
-      a = rand_int(size: :medium, time: t)
-      b = rand_int(size: :medium, time: t)
-      refute b == a + 1
+    test "non-monotonic generation is unaffected (not a monotonic sequence)" do
+      refute monotonic?(size: :medium, time: 1_700_000_300_000)
     end
   end
 
@@ -215,19 +252,9 @@ defmodule UXID.MonotonicTest do
 
   describe "monotonic list config (alias-aware)" do
     test "[:small] applies to both :small and :s but not :medium" do
-      t = 1_700_000_600_000
-
-      small_a = rand_int(size: :small, time: t, monotonic: [:small])
-      small_b = rand_int(size: :small, time: t, monotonic: [:small])
-      assert small_b == small_a + 1
-
-      s_a = rand_int(size: :s, time: t, monotonic: [:small])
-      s_b = rand_int(size: :s, time: t, monotonic: [:small])
-      assert s_b == s_a + 1
-
-      med_a = rand_int(size: :medium, time: t, monotonic: [:small])
-      med_b = rand_int(size: :medium, time: t, monotonic: [:small])
-      refute med_b == med_a + 1
+      assert monotonic?(size: :small, time: 1_700_000_600_000, monotonic: [:small])
+      assert monotonic?(size: :s, time: 1_700_000_600_001, monotonic: [:small])
+      refute monotonic?(size: :medium, time: 1_700_000_600_002, monotonic: [:small])
     end
   end
 
@@ -236,35 +263,24 @@ defmodule UXID.MonotonicTest do
       Application.put_env(:uxid, :monotonic, true)
       on_exit(fn -> Application.delete_env(:uxid, :monotonic) end)
 
-      t = 1_700_000_700_000
-      a = rand_int(size: :medium, time: t, monotonic: false)
-      b = rand_int(size: :medium, time: t, monotonic: false)
-      refute b == a + 1
+      refute monotonic?(size: :medium, time: 1_700_000_700_000, monotonic: false)
     end
 
     test "per-call monotonic: true applies when global is off" do
       Application.put_env(:uxid, :monotonic, false)
       on_exit(fn -> Application.delete_env(:uxid, :monotonic) end)
 
-      t = 1_700_000_700_001
-      a = rand_int(size: :medium, time: t, monotonic: true)
-      b = rand_int(size: :medium, time: t, monotonic: true)
-      assert b == a + 1
+      assert monotonic?(size: :medium, time: 1_700_000_700_001, monotonic: true)
     end
 
     test "global list config applies alias-aware when no per-call option is given" do
       Application.put_env(:uxid, :monotonic, [:small, :medium])
       on_exit(fn -> Application.delete_env(:uxid, :monotonic) end)
 
-      t = 1_700_000_700_002
-      a = rand_int(size: :m, time: t)
-      b = rand_int(size: :m, time: t)
-      assert b == a + 1
+      assert monotonic?(size: :m, time: 1_700_000_700_002)
 
       # A size outside the list is unaffected.
-      la = rand_int(size: :large, time: t)
-      lb = rand_int(size: :large, time: t)
-      refute lb == la + 1
+      refute monotonic?(size: :large, time: 1_700_000_700_003)
     end
   end
 end


### PR DESCRIPTION
Same-millisecond monotonic IDs now advance the random field by a random positive step uniform over [1, 2^(bits/2)] (the sqrt-of-field-space rule, drawn unbiased from the CSPRNG) instead of exactly +1. A step >= 1 keeps the sequence strictly increasing, so uniqueness and K-sortability are unchanged, but consecutive IDs are no longer trivially guessable: single- shot guess cost rises from certainty to ~1/2^(bits/2). Monotonic is unreleased, so this is simply how monotonic works -- no new flag, no config, no wire-format or decoder change.

Tests that relied on the exact +1 relationship now assert strict ordering / uniqueness (via a burst-based monotonic? helper) and step-window bounds, since random steps make exact values non-deterministic.