### PR TITLE
Add UXID.Registry: a compile-time prefix registry

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,4 +1,8 @@
 # Used by "mix format"
 [
-  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"],
+  # Registry DSL — keep these paren-free, and export the rule so apps that
+  # `use UXID.Registry` format their declarations the same way.
+  locals_without_parens: [defid: 1, defid: 2, retired: 1],
+  export: [locals_without_parens: [defid: 1, defid: 2, retired: 1]]
 ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ### Upcoming
 
+* Adds `UXID.Registry`, an opt-in compile-time DSL for an app's prefixes via `use UXID.Registry` with `defid`/`retired`:
+  - Compile-time uniqueness (active and `retired` prefixes) and prefix-format checks, replacing per-app CI tests
+  - By-key API: `generate!/1`, `generate/1`, `prefix/1`, `size/1`, `schema/1`, `category/1`, `field_opts/1`, `all/0`, `keys/0`, `reserved/0`
+  - By-ID-string routing (prefix → schema): `known?/1`, `key_for/1`, `schema_for/1`, `resolve/1`; parsing splits on the last delimiter (unambiguous because a Base32 body never contains it), and the configurable delimiter is validated as Base32-disjoint (defaults to `_`)
+  - JSON manifest export (`manifest/0`, `manifest_json/0`) so database functions and mobile/JS clients mint prefixes from the same source of truth, with no added dependency
+  - Registers `defid`/`retired` as paren-free locals and exports the rule for consuming apps
 * Adds opt-in monotonic generation via the `monotonic` option (per-call/per-field) or `config :uxid, :monotonic` global policy:
   - Accepts `true`/`false`, or a list of sizes (alias-aware, e.g. `[:small]` matches both `:small` and `:s`)
   - Within a millisecond the random field is seeded once then advanced by a random positive step (uniform over `[1, 2^(bits/2)]`, drawn from the CSPRNG), guaranteeing uniqueness and K-sortability for a burst — process-local, `async: true` safe, no GenServer/ETS

--- a/README.md
+++ b/README.md
@@ -240,6 +240,106 @@ explicit `compact_time: false` on `:xs`/`:xsmall` with monotonic on raises an
 sorting are unaffected, but decoding the timestamp back out of a monotonic `:xs`
 is unreliable.
 
+## Prefix Registry
+
+A prefix only pays off — "the ID names its resource on sight" — when it is
+globally unique and well-formed across your whole app. `UXID.Registry` is an
+opt-in, compile-time DSL that makes those guarantees the compiler's job instead
+of a hand-rolled CI test, and turns the same declarations into a runtime
+routing table (prefix → schema) for the ID-driven patterns Adam Kirk describes
+in his ElixirConf US 2025 talk, [_UXIDs in Elixir/Ecto_][uxid_talk_url]
+(authorization/IDOR checks, admin auto-linking, Relay global IDs).
+
+Declare one registry module as your single source of truth:
+
+```elixir
+defmodule MyApp.IDs do
+  use UXID.Registry,
+    default_size: :medium,
+    default_validate: true
+
+  defid :org,     prefix: "org",     schema: MyApp.Org,         category: :account
+  defid :contact, prefix: "contact", size: :large, schema: MyApp.CRM.Contact
+  defid :lead,    prefix: "lead"
+  retired "usr" # reserve a prefix so it stays unique-checked, never reused
+end
+```
+
+**Compile-time guarantees.** Every prefix is checked against `:prefix_format`
+(overridable; the default permits an internal underscore for compound prefixes
+like `in_ref`), and all prefixes — active *and* `retired` — are checked for
+uniqueness. A malformed or duplicate prefix is a compile error, so the governance
+every prefixed-ID scheme needs ships in the library.
+
+**By key** — minting and schema configuration:
+
+```elixir
+MyApp.IDs.generate!(:org)   # => "org_01h…"
+MyApp.IDs.prefix(:org)      # => "org"
+MyApp.IDs.size(:org)        # => :medium
+MyApp.IDs.schema(:org)      # => MyApp.Org
+MyApp.IDs.all()             # => [%{key: :org, prefix: "org", schema: MyApp.Org, ...}, ...]
+```
+
+`field_opts/1` is the single-source-of-truth hook — a schema spreads it instead
+of restating prefix/size/validate anywhere:
+
+```elixir
+@primary_key {:id, UXID, [autogenerate: true] ++ MyApp.IDs.field_opts(:org)}
+```
+
+**By ID string** — the runtime routing table (the "which resource is this?" map):
+
+```elixir
+MyApp.IDs.known?("org_01h…")      # => true   (cheap prefix-only membership check)
+MyApp.IDs.key_for("org_01h…")     # => :org
+MyApp.IDs.schema_for("org_01h…")  # => MyApp.Org
+MyApp.IDs.resolve("org_01h…")     # => %{key: :org, schema: MyApp.Org, category: :account, ...}
+```
+
+Lookups split an ID on the **last** delimiter, which is unambiguous without any
+registry lookup because a UXID body is Crockford Base32 and never contains the
+delimiter — so `in_ref_01h…` recovers the `in_ref` prefix cleanly. For that
+reason the `:delimiter` must be a character that cannot appear in a Base32 body
+(`"_"` — the default — or `"-"`); an underscore is preferred for compound
+prefixes since it does not break double-click-to-select-the-whole-id.
+
+### Sharing the registry across sources (JSON manifest)
+
+UXIDs are source-agnostic — you can mint them in Postgres with `INSERT ... SELECT`
+or on a mobile/JS client that generates an ID offline before upload. To keep the
+Elixir registry the single source of truth in those places too, export a JSON
+manifest and let the other runtime read it:
+
+```elixir
+MyApp.IDs.manifest()
+# => [%{"key" => "org", "prefix" => "org", "size" => "medium", "category" => "account"}, ...]
+
+MyApp.IDs.manifest_json()
+# => ~s([{"key":"org","prefix":"org","size":"medium","category":"account"}, ...])
+```
+
+`manifest/0` returns plain JSON-safe data (string keys, scalar values, `nil` for
+unset fields) that you can hand to any JSON library; `manifest_json/0` returns a
+ready-to-write string with no extra dependency. A common pattern is a tiny Mix
+task or release step that writes it to a file your database migrations or client
+build consume, so every generator agrees on prefixes and sizes:
+
+```elixir
+# lib/mix/tasks/uxid.manifest.ex
+defmodule Mix.Tasks.Uxid.Manifest do
+  use Mix.Task
+  @shortdoc "Writes the UXID prefix manifest to priv/uxid_manifest.json"
+  def run(_args) do
+    File.write!("priv/uxid_manifest.json", MyApp.IDs.manifest_json())
+  end
+end
+```
+
+The manifest carries `prefix`, `size` (which fixes the random length), `category`,
+and `key`; combine each `prefix` with the registry's delimiter and a Base32 body
+to assemble an ID anywhere.
+
 ## Installation
 
 The package can be installed by adding `uxid` to your list of dependencies in `mix.exs`:
@@ -259,6 +359,7 @@ Online documenttion can be found at [https://hexdocs.pm/uxid][hexdocs_project_ur
 [hex_project_url]: https://hex.pm/packages/uxid
 [hexdocs_project_url]: https://hexdocs.pm/uxid
 [mit_license_url]: http://opensource.org/licenses/MIT
+[uxid_talk_url]: https://www.youtube.com/watch?v=YIIJClhjxOA
 
 <!-- BADGES -->
 [badge_license_url]: https://img.shields.io/badge/license-MIT-brightgreen.svg?cacheSeconds=3600?style=flat-square

--- a/lib/uxid/registry.ex
+++ b/lib/uxid/registry.ex
@@ -1,0 +1,441 @@
+defmodule UXID.Registry do
+  @moduledoc """
+  A compile-time registry of an application's UXID prefixes.
+
+  Prefixes only deliver their value — "the ID names its resource on sight" — if
+  they are globally unique and well-formed across an app. `use UXID.Registry`
+  moves that governance out of hand-rolled CI tests and into the compiler, and
+  turns the same declarations into a runtime routing table (prefix → schema)
+  that powers authorization checks, admin auto-linking, and Relay-style global
+  object identification.
+
+  ## Declaring a registry
+
+      defmodule MyApp.IDs do
+        use UXID.Registry,
+          prefix_format: ~r/^[a-z][a-z0-9_]{1,7}$/,
+          delimiter: "_",
+          default_size: :medium,
+          default_validate: true
+
+        defid :org,     prefix: "org",    schema: MyApp.Org,         category: :account
+        defid :contact, prefix: "contact", size: :large, schema: MyApp.CRM.Contact, allow_uuid: true
+        defid :lead,    prefix: "lead",   schema: MyApp.CRM.Lead
+        retired "usr" # reserve a prefix so it counts for uniqueness, never reused
+      end
+
+  ## Compile-time guarantees
+
+    * every `:prefix` is checked against `:prefix_format` — a malformed prefix is
+      a compile error;
+    * all prefixes (active *and* `retired`) are checked for uniqueness — a
+      duplicate is a compile error. This replaces the per-app runtime uniqueness
+      test.
+
+  ## Generated API
+
+  By key (minting and schema configuration):
+
+      MyApp.IDs.generate!(:org)   # => "org_01h…"
+      MyApp.IDs.prefix(:org)      # => "org"
+      MyApp.IDs.size(:org)        # => :medium
+      MyApp.IDs.schema(:org)      # => MyApp.Org
+      MyApp.IDs.field_opts(:org)  # => [prefix: "org", size: :medium, validate: true, allow_uuid: true, delimiter: "_"]
+      MyApp.IDs.all()             # => [%{key: :org, prefix: "org", ...}, ...]
+
+  Cross-source single source of truth — emit a JSON manifest so a database
+  function or a mobile/JS generator mints prefixes the same way the app does:
+
+      MyApp.IDs.manifest()        # => [%{"key" => "org", "prefix" => "org", "size" => "medium", ...}]
+      MyApp.IDs.manifest_json()   # => ~s([{"key":"org","prefix":"org","size":"medium","category":"account"},...])
+
+  `field_opts/1` is the single-source-of-truth hook — a schema spreads it instead
+  of restating anything:
+
+      @primary_key {:id, UXID, [autogenerate: true] ++ MyApp.IDs.field_opts(:org)}
+
+  By ID string (runtime routing — see "Parsing" below):
+
+      MyApp.IDs.known?("org_01h…")      # => true   (cheap prefix-only membership)
+      MyApp.IDs.key_for("org_01h…")     # => :org
+      MyApp.IDs.schema_for("org_01h…")  # => MyApp.Org
+      MyApp.IDs.resolve("org_01h…")     # => %{key: :org, schema: MyApp.Org, ...}
+
+  ## Parsing
+
+  Lookups split an ID into `{prefix, body}` on the **last** delimiter. This is
+  unambiguous without consulting the registry, because a UXID body is Crockford
+  Base32 and therefore never contains the delimiter: in `in_ref_01h…` every `_`
+  belongs to the prefix except the final joining one. The registry is consulted
+  only *after* the split, to answer membership/type — an unregistered but
+  well-formed string like `nope_01h…` parses fine yet resolves to `nil`.
+
+  Because of that, the `:delimiter` must be a character that cannot appear in a
+  Base32 body (`"_"` or `"-"`); a letter or digit is rejected at compile time.
+  An underscore is preferred for compound prefixes since it does not break
+  double-click-to-select-the-whole-id.
+  """
+
+  @default_prefix_format ~r/^[a-z][a-z0-9_]{1,7}$/
+
+  # A Base32 body character in either case; a delimiter must NOT be one of these,
+  # otherwise the split-on-last-delimiter rule becomes ambiguous.
+  @body_char ~r/\A[0-9ABCDEFGHJKMNPQRSTVWXYZabcdefghjkmnpqrstvwxyz]\z/
+
+  @doc "The built-in default `:prefix_format` (permits an internal underscore)."
+  def default_prefix_format(), do: @default_prefix_format
+
+  @doc """
+  Splits a UXID string into `{prefix, body}` on the last occurrence of
+  `delimiter`. Returns `{nil, string}` when the delimiter is absent.
+
+      iex> UXID.Registry.split_last("in_ref_01h2x…", "_")
+      {"in_ref", "01h2x…"}
+
+      iex> UXID.Registry.split_last("01h2x…", "_")
+      {nil, "01h2x…"}
+  """
+  @spec split_last(String.t(), String.t()) :: {String.t() | nil, String.t()}
+  def split_last(string, delimiter) when is_binary(string) and is_binary(delimiter) do
+    case :binary.matches(string, delimiter) do
+      [] ->
+        {nil, string}
+
+      matches ->
+        {pos, len} = List.last(matches)
+        <<prefix::binary-size(pos), _::binary-size(len), body::binary>> = string
+        {prefix, body}
+    end
+  end
+
+  defmacro __using__(opts) do
+    quote bind_quoted: [opts: opts] do
+      import UXID.Registry, only: [defid: 1, defid: 2, retired: 1]
+
+      Module.register_attribute(__MODULE__, :uxid_entries, accumulate: true)
+      Module.register_attribute(__MODULE__, :uxid_reserved, accumulate: true)
+
+      @uxid_prefix_format Keyword.get(opts, :prefix_format, UXID.Registry.default_prefix_format())
+      @uxid_delimiter Keyword.get(opts, :delimiter, UXID.default_delimiter())
+      @uxid_default_size Keyword.get(opts, :default_size)
+      @uxid_default_validate Keyword.get(opts, :default_validate, true)
+
+      @before_compile UXID.Registry
+    end
+  end
+
+  @doc """
+  Registers an id under `key`. Requires `:prefix`; `:size`, `:schema`,
+  `:category`, `:validate`, and `:allow_uuid` are optional and fall back to the
+  registry defaults.
+  """
+  defmacro defid(key, opts \\ []) do
+    quote bind_quoted: [key: key, opts: opts] do
+      @uxid_entries {key, opts}
+    end
+  end
+
+  @doc """
+  Reserves a prefix so it participates in the uniqueness check but is never
+  generated — mirroring "identifiers are never reused". Accepts a string or atom.
+  """
+  defmacro retired(prefix) do
+    quote bind_quoted: [prefix: prefix] do
+      @uxid_reserved prefix
+    end
+  end
+
+  # This macro emits the registry's whole public API as one quoted block, so its
+  # cyclomatic count reflects the number of generated functions, not branching
+  # logic — the actual branching lives in the small runtime helpers below.
+  # credo:disable-for-next-line Credo.Check.Refactor.CyclomaticComplexity
+  defmacro __before_compile__(env) do
+    module = env.module
+    format = Module.get_attribute(module, :uxid_prefix_format)
+    delimiter = Module.get_attribute(module, :uxid_delimiter)
+    default_size = Module.get_attribute(module, :uxid_default_size)
+    default_validate = Module.get_attribute(module, :uxid_default_validate)
+
+    validate_delimiter!(module, delimiter)
+
+    entries =
+      module
+      |> Module.get_attribute(:uxid_entries)
+      |> Enum.reverse()
+      |> Enum.map(&normalize_entry(&1, module, default_size, default_validate))
+
+    reserved =
+      module
+      |> Module.get_attribute(:uxid_reserved)
+      |> Enum.reverse()
+      |> Enum.map(&to_string/1)
+
+    validate_keys!(module, entries)
+    validate_formats!(module, entries, format)
+    validate_uniqueness!(module, entries, reserved)
+
+    index = Map.new(entries, &{&1.prefix, &1})
+    by_key = Map.new(entries, &{&1.key, &1})
+
+    # The generated module stays a thin façade of delegations; the branching
+    # logic lives in the runtime helpers below so it is analysed (and tested)
+    # once, rather than re-inlined into every registry.
+    quote do
+      @uxid_entries_data unquote(Macro.escape(entries))
+      @uxid_by_key unquote(Macro.escape(by_key))
+      @uxid_index unquote(Macro.escape(index))
+      @uxid_reserved_data unquote(reserved)
+      @uxid_delimiter_str unquote(delimiter)
+
+      @doc "All registered (non-retired) ids, in declaration order."
+      def all(), do: @uxid_entries_data
+
+      @doc "The registered keys, in declaration order."
+      def keys(), do: unquote(Enum.map(entries, & &1.key))
+
+      @doc "Reserved (retired) prefixes — unique-checked but never generated."
+      def reserved(), do: @uxid_reserved_data
+
+      @doc """
+      A JSON-safe manifest of the registered ids — a list of maps with string
+      keys and scalar (`prefix`, `size`, `category`, `key`) values, `nil` where
+      unset. This is the cross-source single source of truth: emit it so a
+      database function or a mobile/JS generator mints prefixes the same way the
+      Elixir app does. Encode it with any JSON library, or use `manifest_json/0`.
+      """
+      def manifest(), do: UXID.Registry.manifest(all())
+
+      @doc "The `manifest/0` encoded as a JSON string (deterministic field order)."
+      def manifest_json(), do: UXID.Registry.manifest_json(all())
+
+      @doc "The registry entry for `key` (or `nil`)."
+      def entry(key), do: Map.get(@uxid_by_key, key)
+
+      @doc "The registry entry for `key`, raising if it is unknown."
+      def fetch!(key), do: UXID.Registry.fetch_entry!(@uxid_by_key, key, __MODULE__)
+
+      @doc "The prefix for `key`."
+      def prefix(key), do: fetch!(key).prefix
+
+      @doc "The size for `key`."
+      def size(key), do: fetch!(key).size
+
+      @doc "The schema module for `key` (or `nil`)."
+      def schema(key), do: fetch!(key).schema
+
+      @doc "The category for `key` (or `nil`)."
+      def category(key), do: fetch!(key).category
+
+      @doc """
+      The Ecto field / `UXID` options for `key`: prefix, size, validate,
+      allow_uuid, and the registry delimiter. Spread into a schema field.
+      """
+      def field_opts(key), do: UXID.Registry.field_opts_for(fetch!(key), @uxid_delimiter_str)
+
+      @doc "Generates a UXID for `key`. See `UXID.generate!/1`."
+      def generate!(key),
+        do: UXID.generate!(UXID.Registry.gen_opts(fetch!(key), @uxid_delimiter_str))
+
+      @doc "Generates a UXID for `key`, wrapped in `{:ok, uxid}`."
+      def generate(key),
+        do: UXID.generate(UXID.Registry.gen_opts(fetch!(key), @uxid_delimiter_str))
+
+      @doc """
+      The full registry entry for an ID string, or `nil` if its prefix is not
+      registered. Parsing splits on the last delimiter; the registry answers
+      membership/type.
+      """
+      def resolve(id), do: UXID.Registry.resolve_id(@uxid_index, id, @uxid_delimiter_str)
+
+      @doc """
+      Cheap prefix-only membership check for an ID string — the pre-filter for an
+      IDOR scan path. Does not validate the body.
+      """
+      def known?(id), do: UXID.Registry.known_id?(@uxid_index, id, @uxid_delimiter_str)
+
+      @doc "The registered key for an ID string (or `nil`)."
+      def key_for(id), do: UXID.Registry.field_of(resolve(id), :key)
+
+      @doc "The schema module for an ID string (or `nil`) — the prefix→schema map."
+      def schema_for(id), do: UXID.Registry.field_of(resolve(id), :schema)
+    end
+  end
+
+  # === Runtime helpers (called by generated registry modules) ===
+
+  @doc false
+  def fetch_entry!(by_key, key, module) do
+    case Map.get(by_key, key) do
+      nil ->
+        raise ArgumentError,
+              "#{inspect(key)} is not a registered UXID key in #{inspect(module)}. " <>
+                "Known keys: #{inspect(Map.keys(by_key))}"
+
+      entry ->
+        entry
+    end
+  end
+
+  @doc false
+  def field_opts_for(entry, delimiter) do
+    [
+      prefix: entry.prefix,
+      size: entry.size,
+      validate: entry.validate,
+      allow_uuid: entry.allow_uuid,
+      delimiter: delimiter
+    ]
+  end
+
+  @doc false
+  def gen_opts(entry, delimiter),
+    do: [prefix: entry.prefix, size: entry.size, delimiter: delimiter]
+
+  @doc false
+  def resolve_id(index, id, delimiter) when is_binary(id) do
+    {prefix, _body} = split_last(id, delimiter)
+    Map.get(index, prefix)
+  end
+
+  def resolve_id(_index, _id, _delimiter), do: nil
+
+  @doc false
+  def known_id?(index, id, delimiter) when is_binary(id) do
+    {prefix, _body} = split_last(id, delimiter)
+    Map.has_key?(index, prefix)
+  end
+
+  def known_id?(_index, _id, _delimiter), do: false
+
+  @doc false
+  def field_of(nil, _field), do: nil
+  def field_of(entry, field), do: Map.get(entry, field)
+
+  @manifest_fields [:key, :prefix, :size, :category]
+
+  @doc false
+  def manifest(entries) do
+    Enum.map(entries, fn entry ->
+      Map.new(@manifest_fields, fn field ->
+        {Atom.to_string(field), scalar(Map.get(entry, field))}
+      end)
+    end)
+  end
+
+  @doc false
+  def manifest_json(entries) do
+    "[" <> Enum.map_join(entries, ",", &entry_json/1) <> "]"
+  end
+
+  # A registry field value rendered as a JSON-safe scalar: atoms become strings,
+  # nil stays nil (JSON null), strings pass through.
+  defp scalar(nil), do: nil
+  defp scalar(value) when is_atom(value), do: Atom.to_string(value)
+  defp scalar(value) when is_binary(value), do: value
+
+  defp entry_json(entry) do
+    inner =
+      Enum.map_join(@manifest_fields, ",", fn field ->
+        json_string(Atom.to_string(field)) <> ":" <> json_value(scalar(Map.get(entry, field)))
+      end)
+
+    "{" <> inner <> "}"
+  end
+
+  defp json_value(nil), do: "null"
+  defp json_value(value) when is_binary(value), do: json_string(value)
+
+  defp json_string(value), do: IO.iodata_to_binary([?", escape(value), ?"])
+
+  defp escape(string), do: for(<<char <- string>>, into: "", do: escape_char(char))
+
+  defp escape_char(?\"), do: "\\\""
+  defp escape_char(?\\), do: "\\\\"
+  defp escape_char(?\n), do: "\\n"
+  defp escape_char(?\r), do: "\\r"
+  defp escape_char(?\t), do: "\\t"
+
+  defp escape_char(char) when char < 0x20,
+    do: "\\u" <> String.pad_leading(Integer.to_string(char, 16), 4, "0")
+
+  defp escape_char(char), do: <<char>>
+
+  # === Compile-time helpers (run inside __before_compile__) ===
+
+  defp normalize_entry({key, opts}, module, default_size, default_validate) do
+    unless is_atom(key) do
+      raise ArgumentError, "defid key must be an atom in #{inspect(module)}, got: #{inspect(key)}"
+    end
+
+    prefix = Keyword.get(opts, :prefix)
+
+    unless is_binary(prefix) do
+      raise ArgumentError,
+            "defid #{inspect(key)} in #{inspect(module)} requires a string :prefix, " <>
+              "got: #{inspect(prefix)}"
+    end
+
+    %{
+      key: key,
+      prefix: prefix,
+      size: Keyword.get(opts, :size, default_size),
+      schema: Keyword.get(opts, :schema),
+      category: Keyword.get(opts, :category),
+      validate: Keyword.get(opts, :validate, default_validate),
+      allow_uuid: Keyword.get(opts, :allow_uuid, true)
+    }
+  end
+
+  defp validate_delimiter!(module, delimiter) do
+    valid? =
+      is_binary(delimiter) and String.length(delimiter) == 1 and
+        not Regex.match?(@body_char, delimiter)
+
+    unless valid? do
+      raise ArgumentError,
+            "UXID.Registry :delimiter in #{inspect(module)} must be a single character that " <>
+              "cannot appear in a Base32 body (e.g. \"_\" or \"-\"), got: #{inspect(delimiter)}"
+    end
+  end
+
+  defp validate_keys!(module, entries) do
+    entries
+    |> Enum.map(& &1.key)
+    |> duplicates()
+    |> case do
+      [] -> :ok
+      dupes -> raise ArgumentError, "duplicate UXID keys in #{inspect(module)}: #{inspect(dupes)}"
+    end
+  end
+
+  defp validate_formats!(module, entries, format) do
+    for %{key: key, prefix: prefix} <- entries, not Regex.match?(format, prefix) do
+      raise ArgumentError,
+            "UXID prefix #{inspect(prefix)} for #{inspect(key)} in #{inspect(module)} does not " <>
+              "match #{inspect(format)}"
+    end
+
+    :ok
+  end
+
+  defp validate_uniqueness!(module, entries, reserved) do
+    (Enum.map(entries, & &1.prefix) ++ reserved)
+    |> duplicates()
+    |> case do
+      [] ->
+        :ok
+
+      dupes ->
+        raise ArgumentError,
+              "duplicate UXID prefixes in #{inspect(module)} (including retired): " <>
+                inspect(dupes)
+    end
+  end
+
+  defp duplicates(list) do
+    list
+    |> Enum.frequencies()
+    |> Enum.filter(fn {_value, count} -> count > 1 end)
+    |> Enum.map(&elem(&1, 0))
+  end
+end

--- a/test/support/test_ids.ex
+++ b/test/support/test_ids.ex
@@ -1,0 +1,27 @@
+defmodule UXID.TestSupport.Org do
+  @moduledoc false
+end
+
+defmodule UXID.TestSupport.Contact do
+  @moduledoc false
+end
+
+defmodule UXID.TestSupport.IDs do
+  @moduledoc false
+  use UXID.Registry,
+    default_size: :medium,
+    default_validate: true
+
+  defid :org, prefix: "org", schema: UXID.TestSupport.Org, category: :account
+
+  defid :contact,
+    prefix: "contact",
+    size: :large,
+    schema: UXID.TestSupport.Contact,
+    allow_uuid: false
+
+  defid :lead, prefix: "lead"
+  defid :in_ref, prefix: "in_ref", size: :small
+
+  retired "usr"
+end

--- a/test/uxid/registry_test.exs
+++ b/test/uxid/registry_test.exs
@@ -1,0 +1,186 @@
+defmodule UXID.RegistryTest do
+  use ExUnit.Case, async: true
+
+  doctest UXID.Registry
+
+  alias UXID.TestSupport.{Contact, IDs, Org}
+
+  describe "by-key API" do
+    test "prefix/1, size/1, schema/1, category/1" do
+      assert IDs.prefix(:org) == "org"
+      assert IDs.size(:org) == :medium
+      assert IDs.schema(:org) == Org
+      assert IDs.category(:org) == :account
+    end
+
+    test "size falls back to default_size" do
+      assert IDs.size(:lead) == :medium
+    end
+
+    test "schema/category default to nil" do
+      assert IDs.schema(:lead) == nil
+      assert IDs.category(:lead) == nil
+    end
+
+    test "fetch! raises on an unknown key" do
+      assert_raise ArgumentError, ~r/not a registered UXID key/, fn -> IDs.prefix(:nope) end
+    end
+
+    test "entry/1 returns nil for an unknown key" do
+      assert IDs.entry(:nope) == nil
+    end
+
+    test "field_opts/1 carries prefix, size, validate, allow_uuid, delimiter" do
+      assert IDs.field_opts(:org) == [
+               prefix: "org",
+               size: :medium,
+               validate: true,
+               allow_uuid: true,
+               delimiter: "_"
+             ]
+
+      assert Keyword.get(IDs.field_opts(:contact), :allow_uuid) == false
+    end
+
+    test "all/0 lists entries in declaration order" do
+      assert Enum.map(IDs.all(), & &1.key) == [:org, :contact, :lead, :in_ref]
+    end
+
+    test "keys/0 and reserved/0" do
+      assert IDs.keys() == [:org, :contact, :lead, :in_ref]
+      assert IDs.reserved() == ["usr"]
+    end
+
+    test "generate!/1 mints an ID with the registered prefix" do
+      id = IDs.generate!(:org)
+      assert String.starts_with?(id, "org_")
+      assert IDs.key_for(id) == :org
+    end
+
+    test "generate/1 returns an ok tuple" do
+      assert {:ok, id} = IDs.generate(:contact)
+      assert String.starts_with?(id, "contact_")
+    end
+  end
+
+  describe "JSON manifest" do
+    test "manifest/0 is JSON-safe data with string keys and scalar values" do
+      assert %{"key" => "org", "prefix" => "org", "size" => "medium", "category" => "account"} =
+               Enum.find(IDs.manifest(), &(&1["key"] == "org"))
+    end
+
+    test "manifest/0 renders unset size/category as nil" do
+      lead = Enum.find(IDs.manifest(), &(&1["key"] == "lead"))
+      assert lead == %{"key" => "lead", "prefix" => "lead", "size" => "medium", "category" => nil}
+    end
+
+    test "manifest_json/0 emits deterministic JSON with nulls" do
+      json = IDs.manifest_json()
+
+      assert String.starts_with?(json, "[")
+      assert String.ends_with?(json, "]")
+
+      assert json =~
+               ~s({"key":"org","prefix":"org","size":"medium","category":"account"})
+
+      assert json =~ ~s({"key":"lead","prefix":"lead","size":"medium","category":null})
+    end
+  end
+
+  describe "by-ID-string routing" do
+    test "known?/1 is a cheap prefix membership check" do
+      assert IDs.known?("org_01h2xssfw0000000000000000")
+      refute IDs.known?("nope_01h2xssfw0000000000000000")
+      refute IDs.known?("bare01h2xssfw0")
+      refute IDs.known?(:not_a_binary)
+    end
+
+    test "resolve/1, key_for/1, schema_for/1" do
+      id = "contact_01h2xssfw0000000000000000"
+      assert %{key: :contact, schema: Contact} = IDs.resolve(id)
+      assert IDs.key_for(id) == :contact
+      assert IDs.schema_for(id) == Contact
+    end
+
+    test "unregistered prefixes resolve to nil" do
+      assert IDs.resolve("nope_01h2xssfw0000000000000000") == nil
+      assert IDs.key_for("nope_01h2xssfw0000000000000000") == nil
+      assert IDs.schema_for("nope_01h2xssfw0000000000000000") == nil
+    end
+
+    test "compound underscore prefixes round-trip via split-on-last-delimiter" do
+      id = IDs.generate!(:in_ref)
+      assert String.starts_with?(id, "in_ref_")
+      assert IDs.key_for(id) == :in_ref
+    end
+  end
+
+  describe "split_last/2" do
+    test "splits on the last delimiter" do
+      assert UXID.Registry.split_last("in_ref_01h2x", "_") == {"in_ref", "01h2x"}
+    end
+
+    test "returns nil prefix when the delimiter is absent" do
+      assert UXID.Registry.split_last("01h2x", "_") == {nil, "01h2x"}
+    end
+  end
+
+  describe "compile-time validation" do
+    test "rejects a malformed prefix" do
+      assert_raise ArgumentError, ~r/does not match/, fn ->
+        Code.compile_string("""
+        defmodule Sample.BadFormat do
+          use UXID.Registry
+          defid :bad, prefix: "NOPE!"
+        end
+        """)
+      end
+    end
+
+    test "rejects duplicate prefixes (including retired)" do
+      assert_raise ArgumentError, ~r/duplicate UXID prefixes/, fn ->
+        Code.compile_string("""
+        defmodule Sample.DupPrefix do
+          use UXID.Registry
+          defid :a, prefix: "dup"
+          retired "dup"
+        end
+        """)
+      end
+    end
+
+    test "rejects duplicate keys" do
+      assert_raise ArgumentError, ~r/duplicate UXID keys/, fn ->
+        Code.compile_string("""
+        defmodule Sample.DupKey do
+          use UXID.Registry
+          defid :a, prefix: "aa"
+          defid :a, prefix: "bb"
+        end
+        """)
+      end
+    end
+
+    test "rejects a missing prefix" do
+      assert_raise ArgumentError, ~r/requires a string :prefix/, fn ->
+        Code.compile_string("""
+        defmodule Sample.NoPrefix do
+          use UXID.Registry
+          defid :a
+        end
+        """)
+      end
+    end
+
+    test "rejects a delimiter that can appear in a Base32 body" do
+      assert_raise ArgumentError, ~r/single character that cannot appear/, fn ->
+        Code.compile_string("""
+        defmodule Sample.BadDelimiter do
+          use UXID.Registry, delimiter: "a"
+          defid :a, prefix: "aa"
+        end
+        """)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Governance and runtime routing for an app's UXID prefixes, opt-in via `use UXID.Registry`.

- Compile-time uniqueness (active + retired prefixes) and prefix-format checks, replacing per-app CI tests.
- By-key API: generate!/generate, prefix, size, schema, category, field_opts, all, keys, reserved.
- By-ID-string routing (prefix -> schema): known?, key_for, schema_for, resolve. Parsing splits on the last delimiter, which is unambiguous because a Base32 body never contains the delimiter; delimiter is configurable and validated as Base32-disjoint, defaulting to "_".
- JSON manifest export (manifest/0, manifest_json/0) so database functions and mobile/JS clients mint prefixes from the same source of truth, with a small dependency-free encoder.
- Registers defid/retired as paren-free locals in .formatter.exs and exports the rule for consuming apps.