### PR TITLE
Adds deterministic (name-based) UXIDs via from:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Upcoming
 
+* Adds opt-in **deterministic (name-based) IDs** via the `from:` option on `generate/1`, `generate!/1`, and `new/1` — the same input string always maps to the same ID (UUIDv5-style), across processes and machines:
+  - Body is a truncated **SHA-256** of the input (SHA-256, not the deprecated SHA-1 of real UUIDv5, since no wire interop is needed)
+  - The **prefix is the namespace** (folded into the hash), so the same string under two prefixes yields two unrelated bodies; no separate `namespace:` option
+  - Marked with a leading `z`/`Z` (Crockford value 31): self-identifying and sorts *after* every time-based ID; not K-sortable among themselves
+  - Reserves value 31 in compact-time encoding so `z`/`Z` is an unambiguous scheme marker — compact timestamps now raise past ~mid-2038 (standard 48-bit timestamps unaffected)
+  - Deterministic bodies reuse the standard (non-compact) lengths per `:size`, spending the whole body (minus the marker) on hash bits (45–125 bits)
+  - `decode/1` reports `deterministic: true` with `time: nil`; adds `UXID.deterministic?/1`
+  - `from:` requires a string (raises otherwise); `from:` with an explicit `monotonic: true` raises (deterministic vs. burst-random); Ecto `autogenerate` is intentionally not wired for `from:` (mint explicitly in a changeset)
+  - Not a secret: a hash of a *known* input is exactly as guessable as the input — do not derive an ID from a low-entropy secret and treat it as unguessable
+
 ## 2.6.0 / 2026-07-17
 
 * Adds runtime prefix → schema routing for **layered apps**, so a `UXID.Registry` can live at an app's base layer without a `schema:` literal inverting the dependency direction:

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Stripe-style identifiers like `usr_01epey2p06tr1rtv07xa82zgjj`. They are:
 * Unlikely to collide — more randomness, lower odds
 * Human-transmissible — easy to read out accurately over the phone
 * Optionally **monotonic** — a burst within one millisecond stays unique and strictly ordered
+* Optionally **deterministic** — the same input string always maps to the same ID (UUIDv5-style), marked with a leading `z` and sorted after time-based IDs
 * Optionally **governed by a registry** — one module keeps every prefix unique and maps an ID back to its resource
 
 Many of the concepts of [Stripe IDs][stripe_ids_url] have been used in this library.
@@ -50,6 +51,10 @@ UXID.generate!(prefix: "cus", size: :small)   # "cus_01eqrh884aqyy1"
 
 # Uppercase to match earlier UXID versions
 UXID.generate!(case: :upper)                  # "01EMDGJF0DQXQJ8FM78XE97Y3H"
+
+# Deterministic: same input -> same id, forever (prefix is the namespace)
+UXID.generate!(prefix: "usr", from: "alice@example.com")
+# => "usr_zcvt7epac0t1ebcsjfyf7cwz25"
 ```
 
 ## Ecto in 30 seconds
@@ -78,6 +83,7 @@ The five-minute path is above; each area has a dedicated guide:
 * **[Sizes & Encoding](guides/sizes.md)** — the t-shirt sizes, how much randomness each carries, and compact-time mode for extra collision resistance.
 * **[Ecto Integration](guides/ecto.md)** — primary/foreign keys, strict `validate:` casting, `allow_uuid` coexistence, and `UXID.valid?/2`.
 * **[Monotonic IDs](guides/monotonic.md)** — guaranteed same-millisecond uniqueness and ordering, the security tradeoff, and when to use it.
+* **[Deterministic IDs](guides/deterministic.md)** — name-based (UUIDv5-style) IDs where the same input always maps to the same ID, with the prefix as the namespace.
 * **[Prefix Registry](guides/registry.md)** — a compile-time DSL that keeps every prefix unique, routes an ID back to its schema, works in layered/umbrella apps, and exports a cross-source JSON manifest.
 * **[Configuration](guides/configuration.md)** — every `config :uxid` key in one place, with per-call vs. global precedence.
 

--- a/guides/deterministic.md
+++ b/guides/deterministic.md
@@ -1,0 +1,124 @@
+# Deterministic IDs
+
+Standard UXIDs are random: calling `generate!/1` twice with the same options
+gives two different IDs. Deterministic mode is the opposite — **the same input
+string always maps to the same ID**, forever, across processes and machines.
+This is what a name-based UUID (UUIDv5) gives you, adapted to the UXID format.
+
+Reach for it when you want a stable ID derived from an external key without a
+lookup table: an email, a vendor SKU, a webhook idempotency key, or a natural key
+during a migration. It makes idempotent upserts trivial (recompute the ID instead
+of querying for it) and gives you stable fixtures and seeds in tests.
+
+## The `from:` API
+
+Passing `from:` switches `generate/1`, `generate!/1`, and `new/1` into
+deterministic mode. Every other option (`prefix:`, `size:`, `case:`,
+`delimiter:`) works unchanged:
+
+```elixir
+UXID.generate!(prefix: "usr", from: "alice@example.com")
+# => "usr_zcvt7epac0t1ebcsjfyf7cwz25"  (stable for this input, forever)
+
+UXID.generate!(prefix: "usr", from: "alice@example.com")  # identical again
+```
+
+The ID is a truncated **SHA-256** of the input. `from:` must be a string; pass a
+non-binary and it raises. For a composite key, stringify it yourself first
+(`"#{tenant}:#{email}"`) so you control the exact bytes that get hashed.
+
+## Prefix is the namespace
+
+The prefix is folded into the hash as the namespace, so the same string under two
+prefixes produces two unrelated bodies — `usr` + `"alice@example.com"` and `org`
++ `"alice@example.com"` never collide:
+
+```elixir
+UXID.generate!(prefix: "usr", from: "alice@example.com")  # "usr_zcvt7epac…"
+UXID.generate!(prefix: "org", from: "alice@example.com")  # "org_zes4c99fn…"  (unrelated)
+```
+
+Most callers pass just `prefix` + `from` and get correct scoping with zero extra
+config. (There is no separate `namespace:` option; the prefix does that job. No
+prefix at all hashes into the global scope.)
+
+## The `z` marker and sort order
+
+A deterministic body always starts with `z` (or `Z` in upper case) — Crockford
+value 31, the maximum symbol. It does two jobs:
+
+1. **Self-identifying** — a human or the decoder can see at a glance that the ID
+   is hash-derived, not time-derived. `UXID.deterministic?/1` reports it, and
+   `decode/1` returns `deterministic: true` with `time: nil`.
+2. **Sorts last** — because `z` is the highest value, every deterministic ID
+   sorts *after* every time-based ID. They cluster at the end of an index instead
+   of interleaving with (and polluting) the K-sortable time range. Among
+   themselves they sort in no meaningful order.
+
+To keep `z` an unambiguous marker, compact-time encoding reserves value 31: a
+compact timestamp can no longer start with `z`, which trims the compact horizon
+to ~mid-2038 (standard 48-bit timestamps are unaffected). See the
+[Sizes & Encoding guide](sizes.md#compact-time).
+
+## Size and length
+
+Deterministic bodies reuse the standard (non-compact) lengths, spending the whole
+body — minus the one-character marker — on hash bits:
+
+| Size          | Aliases      | Body length | Hash bits |
+|---------------|--------------|-------------|-----------|
+| `:xs`         | `:xsmall`    | 10 chars    | 45        |
+| `:s`          | `:small`     | 14 chars    | 65        |
+| `:m`          | `:medium`    | 18 chars    | 85        |
+| `:l`          | `:large`     | 22 chars    | 105       |
+| `:xl`         | `:xlarge`    | 26 chars    | 125       |
+
+With no `:size`, generation defaults to `:xl` (125 hash bits). A deterministic ID
+carries *more* distinguishing bits than the random UXID of the same size, since it
+does not spend characters on a timestamp. Changing `size` changes the ID: the
+same input at two sizes yields unrelated bodies, not one a truncated prefix of the
+other. Case is a display concern applied at encode time — upper and lower are the
+same ID, exactly as for random UXIDs.
+
+## Properties, honestly
+
+- **Deterministic & idempotent** — same `{namespace, name, size, case}` → same ID,
+  everywhere, forever.
+- **Not time-ordered** — hash order is effectively random-but-stable. These sort
+  after time IDs and among themselves in no meaningful order, so do not rely on
+  them for K-sortability.
+- **Not a secret** — a deterministic ID is a hash of a *known* input, so it is
+  exactly as guessable as that input. Anyone who knows the namespace + name can
+  recompute the ID. Do **not** derive an ID from a low-entropy secret and treat
+  the ID as unguessable. (This is the same caveat RFC 4122 gives for name-based
+  UUIDs.)
+
+> #### Deterministic IDs are not unguessable {: .warning}
+>
+> If you need an identifier an attacker cannot guess, use a random UXID (`:large`
+> or `:xl`), not a deterministic one. `from:` is for stability, not secrecy.
+
+## With Ecto
+
+Ecto `autogenerate` is intentionally **not** wired for `from:` — there is no
+per-row input available at autogenerate time. Mint the ID explicitly in
+application code (typically a changeset) and store it as an ordinary string:
+
+```elixir
+def changeset(user, attrs) do
+  user
+  |> cast(attrs, [:email])
+  |> validate_required([:email])
+  |> put_deterministic_id()
+end
+
+defp put_deterministic_id(%{valid?: true, changes: %{email: email}} = changeset) do
+  put_change(changeset, :id, UXID.generate!(prefix: "usr", from: email))
+end
+
+defp put_deterministic_id(changeset), do: changeset
+```
+
+The field itself is a normal `UXID` (or `:string`) column — casting and querying
+are unchanged; you are just supplying the value instead of letting the datastore
+or `autogenerate` mint a random one.

--- a/guides/sizes.md
+++ b/guides/sizes.md
@@ -26,6 +26,10 @@ UXID.generate!(prefix: "cus", size: :small)   # "cus_01eqrh884aqyy1"  (14-char b
 UXID.generate!(prefix: "cus", size: :xl)      # "cus_01kxr2jnqndq7qx9wrvhmrzrhw"
 ```
 
+[Deterministic IDs](deterministic.md) reuse these same body lengths, but spend
+the whole body (minus the one-character `z`/`Z` marker) on hash bits instead of a
+timestamp plus randomness — so a deterministic `:m` body is 85 hash bits, not 40.
+
 ## Collision resistance
 
 Two UXIDs can only collide if they share the **same millisecond timestamp** *and*
@@ -85,7 +89,7 @@ UXID.generate!(size: :small, compact_time: true) # 13-char body, 24 random bits
 - Reduces the timestamp from 48 bits (10 chars) to 40 bits (8 chars).
 - Frees 8 bits for randomness — e.g. `:small` gains 50% more (24 vs 16 bits).
 - Keeps perfect 5-bit Crockford Base32 alignment.
-- Stays K-sortable until ~September 2039, after which the compact timestamp wraps.
+- Stays K-sortable until ~mid-2038, after which the compact encoder raises: value 31 (the first char `z`/`Z`) is reserved as the [deterministic-ID](deterministic.md) scheme marker, so no compact timestamp may emit it. Standard 48-bit timestamps are unaffected.
 - The decoder auto-detects the compact format from the length and reconstructs the full timestamp.
 
 Compact time is useful for test suites that mint IDs rapidly and for small

--- a/lib/uxid.ex
+++ b/lib/uxid.ex
@@ -13,8 +13,19 @@ defmodule UXID do
   * Do not require any coordination (human or automated) at startup, or generation
   * Are very unlikely to collide (more likely with less randomness)
   * Are easily and accurately transmitted to another human using a telephone
+  * Can optionally be deterministic (name-based) — the same input always maps to
+    the same ID
 
   Many of the concepts of Stripe IDs have been used in this library.
+
+  ## Deterministic IDs
+
+  Passing `from:` to `generate/1`, `generate!/1`, or `new/1` produces a
+  deterministic (name-based) ID: the same input string always maps to the same
+  ID (UUIDv5-style), with the prefix acting as the namespace. Deterministic IDs
+  carry a leading `z`/`Z` marker and sort after time-based IDs. They are a hash
+  of a *known* input, so they are not unguessable — see `generate/1` and the
+  Deterministic IDs guide for the full picture.
   """
 
   @typedoc "Options for generating a UXID"
@@ -27,6 +38,7 @@ defmodule UXID do
           | {:delimiter, String.t() | nil}
           | {:compact_time, boolean() | nil}
           | {:monotonic, boolean() | [atom()] | nil}
+          | {:from, String.t() | nil}
 
   @type options :: [option()]
 
@@ -51,6 +63,22 @@ defmodule UXID do
   @spec generate(opts :: options()) :: {:ok, __MODULE__.t()}
   @doc """
   Returns an encoded UXID string along with response status.
+
+  ## Deterministic (name-based) IDs
+
+  Passing `from:` switches to deterministic mode: the same input string always
+  maps to the same ID (UUIDv5-style), across processes and machines, forever. The
+  prefix is folded in as the namespace, so the same string under two prefixes
+  yields two different bodies. `from:` must be a string (raises otherwise).
+
+  Deterministic IDs are marked with a leading `z`/`Z` and sort *after* every
+  time-based ID; they are not K-sortable among themselves. They are a hash of a
+  *known* input, so they are exactly as guessable as that input — do not derive
+  an ID from a low-entropy secret and treat the ID as unguessable.
+
+      {:ok, id} = UXID.generate(prefix: "usr", from: "alice@example.com")
+      # {:ok, "usr_z…"} — identical for this input on every call
+
   """
   def generate(opts \\ []) do
     {:ok, %Codec{string: string}} = new(opts)
@@ -61,6 +89,14 @@ defmodule UXID do
   @spec generate!(opts :: options()) :: __MODULE__.t()
   @doc """
   Returns an unwrapped encoded UXID string.
+
+  Passing `from:` returns a deterministic (name-based) ID: the same input always
+  maps to the same ID, with the prefix acting as the namespace. See `generate/1`
+  for the full deterministic-mode notes.
+
+      UXID.generate!(prefix: "usr", from: "alice@example.com")
+      # => "usr_z…" (stable for this input, forever)
+
   """
   def generate!(opts \\ []) do
     {:ok, uxid} = generate(opts)
@@ -80,10 +116,12 @@ defmodule UXID do
     compact_time = Keyword.get(opts, :compact_time)
     monotonic = Keyword.get(opts, :monotonic)
     timestamp = Keyword.get(opts, :time, System.system_time(:millisecond))
+    from = validate_from(Keyword.get(opts, :from))
 
     %Codec{
       case: case,
       compact_time: compact_time,
+      from: from,
       monotonic: monotonic,
       prefix: prefix,
       rand_size: rand_size,
@@ -93,6 +131,19 @@ defmodule UXID do
     }
     |> Encoder.process()
   end
+
+  # from: switches on deterministic mode and must be a binary. Stringify your own
+  # composite keys before passing them; a non-binary is a caller error, so raise a
+  # crisp message rather than hashing an inspect/1 rendering.
+  defp validate_from(nil), do: nil
+  defp validate_from(from) when is_binary(from), do: from
+
+  defp validate_from(other),
+    do:
+      raise(
+        ArgumentError,
+        "from: must be a string, got: #{inspect(other)} — stringify your key before passing it"
+      )
 
   def encode_case(), do: Application.get_env(:uxid, :case, :lower)
 
@@ -115,7 +166,10 @@ defmodule UXID do
   adding 8 bits to randomness. This is a global policy that can be overridden
   per-call with the `compact_time` option.
   This provides perfect 5-bit Crockford Base32 alignment (8 chars vs 10 chars).
-  K-sortability is maintained until ~September 2039.
+  K-sortability is maintained until ~mid-2038 for compact mode: value 31 (the
+  first char `z`/`Z`) is reserved as the deterministic-ID scheme marker, so
+  compact encoding raises for timestamps at/after that band. Standard 48-bit
+  timestamps are unaffected.
   """
   def compact_small_times(), do: Application.get_env(:uxid, :compact_small_times, false)
 
@@ -188,6 +242,44 @@ defmodule UXID do
 
   def valid?(_term, _opts), do: false
 
+  @spec deterministic?(term(), keyword()) :: boolean()
+  @doc """
+  Returns `true` if the given value is a deterministic (name-based) UXID.
+
+  Deterministic IDs carry a leading `z`/`Z` scheme marker (Crockford value 31)
+  instead of an encoded timestamp, so this only inspects the first body
+  character — it does not otherwise validate structure (pair it with `valid?/2`
+  if you need both). Time-based IDs start with a lower value and return `false`.
+
+  ## Options
+
+    * `:delimiter` - the prefix delimiter (defaults to the configured
+      delimiter, see `default_delimiter/0`).
+
+  ## Examples
+
+      iex> UXID.deterministic?("usr_z9m4k7p2q3r8t5v6w0abcde")
+      true
+
+      iex> UXID.deterministic?("cus_01emdgjf0dqxqj8fm78xe97y3h")
+      false
+
+      iex> UXID.deterministic?("nope!")
+      false
+  """
+  def deterministic?(term, opts \\ [])
+
+  def deterministic?(term, opts) when is_binary(term) do
+    delimiter = Keyword.get(opts, :delimiter, default_delimiter())
+
+    case split_prefix(term, delimiter) do
+      {_prefix, <<first, _::binary>>} when first in [?z, ?Z] -> true
+      _ -> false
+    end
+  end
+
+  def deterministic?(_term, _opts), do: false
+
   defp body_valid?(body) do
     String.length(body) >= @min_body_length and Regex.match?(@crockford_body, body)
   end
@@ -221,6 +313,11 @@ defmodule UXID do
     for opt-in monotonic generation:
 
         field :id, UXID, autogenerate: true, prefix: "evt", size: :small, monotonic: true
+
+    Deterministic (`from:`) IDs are intentionally **not** wired here — there is no
+    per-row input available at autogenerate time. Mint them explicitly in
+    application code (e.g. in a changeset via `generate!/1`) and store/cast the
+    result as an ordinary string.
     """
     def autogenerate(opts) do
       case = Map.get(opts, :case, encode_case())

--- a/lib/uxid/codec.ex
+++ b/lib/uxid/codec.ex
@@ -7,7 +7,15 @@ defmodule UXID.Codec do
     :case,
     :compact_time,
     :delimiter,
+    # `deterministic` records the scheme: set true on the name-based (hash) path,
+    # false/nil on the time-based path. It is stamped during encode (from a `from`
+    # input) and during decode (from the leading `z`/`Z` marker).
+    :deterministic,
     :encoded,
+    # `from` holds the input string for a deterministic (name-based) UXID. When it
+    # is a binary the encoder routes to the deterministic scheme instead of the
+    # time/random one.
+    :from,
     :monotonic,
     :prefix,
     :rand_size,
@@ -23,7 +31,9 @@ defmodule UXID.Codec do
   @type t() :: %__MODULE__{
           case: atom() | nil,
           compact_time: boolean() | nil,
+          deterministic: boolean() | nil,
           encoded: String.t() | nil,
+          from: String.t() | nil,
           monotonic: boolean() | [atom()] | nil,
           prefix: String.t() | nil,
           delimiter: String.t() | nil,

--- a/lib/uxid/decoder.ex
+++ b/lib/uxid/decoder.ex
@@ -24,6 +24,7 @@ defmodule UXID.Decoder do
     decoded =
       struct
       |> separate_prefix()
+      |> detect_scheme()
       |> decode_size()
       |> ensure_compact_time()
       |> separate_encoded()
@@ -33,6 +34,15 @@ defmodule UXID.Decoder do
 
     {:ok, decoded}
   end
+
+  # A leading `z`/`Z` marker (Crockford value 31) identifies a deterministic
+  # (name-based) ID. Deterministic bodies reuse the standard (non-compact)
+  # lengths, so decode_size still infers the right size; only the time field is
+  # meaningless (the body is a hash, not a timestamp).
+  defp detect_scheme(%Codec{encoded: <<first, _::binary>>} = struct) when first in [?z, ?Z],
+    do: %{struct | deterministic: true}
+
+  defp detect_scheme(%Codec{} = struct), do: %{struct | deterministic: false}
 
   @spec separate_prefix(Codec.t()) :: Codec.t()
   def separate_prefix(%Codec{prefix: nil, string: uxid_string} = struct) do
@@ -100,6 +110,10 @@ defmodule UXID.Decoder do
 
   # Decode UXID and extract timestamp
   @spec decode_time(Codec.t()) :: Codec.t()
+  # Deterministic (name-based) IDs carry a hash, not a timestamp — do not decode
+  # the body as time.
+  def decode_time(%Codec{deterministic: true} = struct), do: %{struct | time: nil}
+
   # Compact 40-bit timestamp (8 characters, perfect 5-bit alignment)
   # Requires epoch reconstruction to restore full 48-bit timestamp
   def decode_time(

--- a/lib/uxid/encoder.ex
+++ b/lib/uxid/encoder.ex
@@ -21,6 +21,23 @@ defmodule UXID.Encoder do
     if size_to_index(size1) >= size_to_index(size2), do: size1, else: size2
   end
 
+  # Deterministic (name-based) scheme: a `from` binary short-circuits the
+  # time/random machinery. The prefix is folded into the hash as the namespace, so
+  # the same string under two prefixes yields two different bodies. See
+  # encode_deterministic/1 for the body layout.
+  def process(%Codec{from: from} = struct) when is_binary(from) do
+    uxid =
+      struct
+      |> reject_monotonic_conflict()
+      |> ensure_min_size()
+      |> ensure_case()
+      |> ensure_delimiter()
+      |> encode_deterministic()
+      |> prefix()
+
+    {:ok, uxid}
+  end
+
   def process(%Codec{} = struct) do
     uxid =
       struct
@@ -211,6 +228,69 @@ defmodule UXID.Encoder do
 
   defp ensure_delimiter(uxid), do: uxid
 
+  # from: (deterministic) and an explicit monotonic: true are a contradiction —
+  # one asks for a stable hash, the other for burst-unique randomness. The global
+  # monotonic policy is not consulted on this path; only an explicit true conflicts.
+  defp reject_monotonic_conflict(%Codec{monotonic: true}),
+    do:
+      raise(
+        ArgumentError,
+        "from: (deterministic mode) and monotonic: true are mutually exclusive — " <>
+          "a deterministic ID is a stable hash, not burst-random"
+      )
+
+  defp reject_monotonic_conflict(uxid), do: uxid
+
+  # Encode the body of a deterministic (name-based) UXID.
+  #
+  # Layout: a leading marker char (`z` lower / `Z` upper, Crockford value 31)
+  # followed by Base32 of the top bits of a SHA-256 digest. The marker is
+  # self-identifying (a human/decoder sees it is hash-derived, not time-derived)
+  # and sorts every deterministic ID after every time-based ID (value 31 is the
+  # max symbol).
+  #
+  # The prefix is folded into the hash input as the namespace, so the same string
+  # under two prefixes yields two unrelated bodies. The hash-char count is folded
+  # in too, so the same string at two sizes yields unrelated bodies rather than one
+  # being a truncated prefix of the other. Zero (`0`) bytes separate the fields so
+  # distinct field splits can't alias. Case is a display concern only and is not
+  # part of the hash input.
+  defp encode_deterministic(%Codec{case: case, from: from, prefix: prefix, size: size} = uxid) do
+    nchars = deterministic_hash_chars(size)
+    nbits = nchars * 5
+    digest = :crypto.hash(:sha256, [prefix || "", 0, from, 0, <<nchars>>])
+    <<bits::bitstring-size(nbits), _::bitstring>> = digest
+    marker = if case == :lower, do: <<?z>>, else: <<?Z>>
+    body = marker <> encode_hash_bits(bits, case)
+    %{uxid | encoded: body, deterministic: true}
+  end
+
+  # Recursively consume 5 bits at a time off the digest, reusing the same Crockford
+  # lookup tables as encode_rand.
+  defp encode_hash_bits(<<>>, _case), do: ""
+
+  defp encode_hash_bits(<<v::5, rest::bitstring>>, :lower),
+    do: <<el(v)>> <> encode_hash_bits(rest, :lower)
+
+  defp encode_hash_bits(<<v::5, rest::bitstring>>, case),
+    do: <<e(v)>> <> encode_hash_bits(rest, case)
+
+  # Hash chars per size (body = 1 marker char + this many hash chars). Mirrors the
+  # canonical table in design/deterministic-uxid.md; reuses the standard
+  # (non-compact) lengths so the decoder's @size_by_length inference is unchanged.
+  # nil/unknown sizes default to the xlarge width (25).
+  defp deterministic_hash_chars(:xs), do: 9
+  defp deterministic_hash_chars(:xsmall), do: 9
+  defp deterministic_hash_chars(:s), do: 13
+  defp deterministic_hash_chars(:small), do: 13
+  defp deterministic_hash_chars(:m), do: 17
+  defp deterministic_hash_chars(:medium), do: 17
+  defp deterministic_hash_chars(:l), do: 21
+  defp deterministic_hash_chars(:large), do: 21
+  defp deterministic_hash_chars(:xl), do: 25
+  defp deterministic_hash_chars(:xlarge), do: 25
+  defp deterministic_hash_chars(_), do: 25
+
   defp encode(%Codec{} = input) do
     uxid =
       input
@@ -222,9 +302,20 @@ defmodule UXID.Encoder do
 
   defp encode_time(%Codec{compact_time: true, case: case, time: time, time_encoded: nil} = uxid) do
     # Use only 40 bits of timestamp (remove 8 MSB)
-    # This gives us timestamps valid until ~Sep 2039
+    # This gives compact timestamps valid until ~mid-2038 (value 31 reserved)
     # Perfect 5-bit alignment: 8 characters × 5 bits = 40 bits
     truncated_time = time &&& 0xFFFFFFFFFF
+
+    # The first compact char encodes the top 5 bits (t1). Value 31 (`z`/`Z`) is
+    # reserved as the deterministic-ID scheme marker, so no compact time body may
+    # emit it. t1 only reaches 31 in the final band of the 40-bit epoch (roughly
+    # mid-2038 -> Sep 2039), so this guard bites only for far-future timestamps.
+    if truncated_time >>> 35 == 31 do
+      raise ArgumentError,
+            "compact_time cannot encode timestamps at/after ~mid-2038: value 31 is " <>
+              "reserved as the deterministic-ID scheme marker — use a standard size"
+    end
+
     string = encode_time_compact(<<truncated_time::unsigned-size(40)>>, case)
     %{uxid | time_encoded: string}
   end

--- a/mix.exs
+++ b/mix.exs
@@ -83,6 +83,7 @@ defmodule UXID.MixProject do
         "guides/sizes.md",
         "guides/ecto.md",
         "guides/monotonic.md",
+        "guides/deterministic.md",
         "guides/registry.md",
         "guides/configuration.md",
         "CHANGELOG.md",

--- a/test/uxid/deterministic_test.exs
+++ b/test/uxid/deterministic_test.exs
@@ -1,0 +1,218 @@
+defmodule UXID.DeterministicTest do
+  use ExUnit.Case, async: true
+
+  import Bitwise
+
+  alias UXID.{Codec, Decoder}
+
+  # Body length per size for deterministic IDs (1 marker char + hash chars).
+  # Mirrors the canonical table in design/deterministic-uxid.md.
+  @body_length %{
+    xs: 10,
+    xsmall: 10,
+    s: 14,
+    small: 14,
+    m: 18,
+    medium: 18,
+    l: 22,
+    large: 22,
+    xl: 26,
+    xlarge: 26
+  }
+
+  describe "determinism" do
+    test "same {from, prefix, size, case} yields identical strings across many runs" do
+      ids =
+        for _ <- 1..50 do
+          UXID.generate!(prefix: "usr", from: "alice@example.com", size: :medium)
+        end
+
+      assert Enum.uniq(ids) == [List.first(ids)]
+    end
+
+    test "is independent of the process it runs in" do
+      here = UXID.generate!(prefix: "usr", from: "alice@example.com")
+
+      there =
+        Task.async(fn -> UXID.generate!(prefix: "usr", from: "alice@example.com") end)
+        |> Task.await()
+
+      assert here == there
+    end
+
+    test "generate/1 and new/1 agree with generate!/1" do
+      opts = [prefix: "usr", from: "alice@example.com"]
+
+      assert {:ok, string} = UXID.generate(opts)
+      assert {:ok, %Codec{string: ^string}} = UXID.new(opts)
+      assert UXID.generate!(opts) == string
+    end
+  end
+
+  describe "prefix as namespace" do
+    test "same string under different prefixes yields different bodies" do
+      a = UXID.generate!(prefix: "usr", from: "alice@example.com")
+      b = UXID.generate!(prefix: "org", from: "alice@example.com")
+
+      assert body(a) != body(b)
+    end
+
+    test "no prefix (global scope) works and differs from a prefixed body" do
+      global = UXID.generate!(from: "alice@example.com")
+      scoped = UXID.generate!(prefix: "usr", from: "alice@example.com")
+
+      refute String.contains?(global, "_")
+      assert String.starts_with?(global, "z")
+      assert body(global) != body(scoped)
+    end
+  end
+
+  describe "size" do
+    test "each size yields the canonical body length" do
+      for {size, length} <- @body_length do
+        id = UXID.generate!(prefix: "usr", from: "alice@example.com", size: size)
+        assert String.length(body(id)) == length, "size #{size} produced #{body(id)}"
+      end
+    end
+
+    test "unset size defaults to the xlarge length" do
+      id = UXID.generate!(prefix: "usr", from: "alice@example.com")
+      assert String.length(body(id)) == 26
+    end
+
+    test "same string at two sizes yields unrelated bodies, not a shared prefix" do
+      small = body(UXID.generate!(prefix: "cus", from: "acme-corp", size: :small))
+      medium = body(UXID.generate!(prefix: "cus", from: "acme-corp", size: :medium))
+
+      refute String.starts_with?(medium, small)
+    end
+  end
+
+  describe "case" do
+    test "upper and lower are the same ID in different case" do
+      lower = UXID.generate!(prefix: "usr", from: "x", case: :lower)
+      upper = UXID.generate!(prefix: "usr", from: "x", case: :upper)
+
+      # Case is a display concern applied to the body only; the prefix is
+      # untouched, so the two bodies are the same ID in different case.
+      assert String.upcase(body(lower)) == body(upper)
+    end
+
+    test "the marker follows the case" do
+      assert String.starts_with?(
+               body(UXID.generate!(prefix: "usr", from: "x", case: :lower)),
+               "z"
+             )
+
+      assert String.starts_with?(
+               body(UXID.generate!(prefix: "usr", from: "x", case: :upper)),
+               "Z"
+             )
+    end
+  end
+
+  describe "marker and sorting" do
+    test "the body starts with the z/Z marker" do
+      assert String.starts_with?(body(UXID.generate!(prefix: "usr", from: "x")), "z")
+    end
+
+    test "a deterministic ID sorts after a time-based ID of the same prefix" do
+      time_id = UXID.generate!(prefix: "usr", size: :medium)
+      det_id = UXID.generate!(prefix: "usr", from: "x", size: :medium)
+
+      assert body(det_id) > body(time_id)
+    end
+  end
+
+  describe "round-trip decode" do
+    test "decode reports deterministic: true, time: nil, and the right size" do
+      for {size, _length} <- @body_length do
+        id = UXID.generate!(prefix: "usr", from: "alice@example.com", size: size)
+        {:ok, decoded} = UXID.decode(id)
+
+        assert decoded.deterministic == true
+        assert decoded.time == nil
+        assert decoded.size == canonical_size(size)
+      end
+    end
+
+    test "a time-based ID decodes as deterministic: false with a real time" do
+      {:ok, decoded} = UXID.decode(UXID.generate!(prefix: "cus", size: :medium))
+
+      assert decoded.deterministic == false
+      assert is_integer(decoded.time)
+    end
+
+    test "deterministic?/1 and valid?/2 agree" do
+      det = UXID.generate!(prefix: "usr", from: "x")
+      time = UXID.generate!(prefix: "usr")
+
+      assert UXID.deterministic?(det)
+      refute UXID.deterministic?(time)
+      assert UXID.valid?(det)
+    end
+  end
+
+  describe "conflicts" do
+    test "from: with explicit monotonic: true raises" do
+      assert_raise ArgumentError, ~r/mutually exclusive/, fn ->
+        UXID.generate!(prefix: "usr", from: "x", monotonic: true)
+      end
+    end
+
+    test "a non-binary from: raises" do
+      assert_raise ArgumentError, ~r/must be a string/, fn ->
+        UXID.generate!(prefix: "usr", from: 123)
+      end
+    end
+  end
+
+  describe "compact first-char cap" do
+    # t1 (top 5 bits of the 40-bit compact time) == 31 is reserved as the
+    # deterministic marker, so a compact timestamp in that band must raise.
+    @reserved 31 <<< 35
+
+    test "a reserved-band timestamp raises" do
+      assert_raise ArgumentError, ~r/reserved/, fn ->
+        UXID.generate!(size: :small, compact_time: true, time: @reserved)
+      end
+    end
+
+    test "the timestamp just below the reserved band still encodes" do
+      id = UXID.generate!(size: :small, compact_time: true, time: @reserved - 1)
+      # value 30 -> 'y'
+      assert String.starts_with?(id, "y")
+    end
+
+    test "a normal now-based compact ID is unaffected" do
+      id = UXID.generate!(size: :small, compact_time: true)
+      refute String.starts_with?(id, "z")
+    end
+  end
+
+  describe "golden vectors (wire-format lock)" do
+    test "known {prefix, from, size} map to exact strings" do
+      assert UXID.generate!(prefix: "usr", from: "alice@example.com") ==
+               "usr_zcvt7epac0t1ebcsjfyf7cwz25"
+
+      assert UXID.generate!(prefix: "cus", from: "acme-corp", size: :small) ==
+               "cus_zt9vnyfd85bff0"
+
+      assert UXID.generate!(from: "alice@example.com", size: :medium) ==
+               "zqz4cwzgyw8ks97869"
+    end
+  end
+
+  # The encoded body, with any prefix + delimiter stripped.
+  defp body(uxid) do
+    {:ok, %Codec{encoded: encoded}} = Decoder.process(%Codec{string: uxid})
+    encoded
+  end
+
+  defp canonical_size(:xs), do: :xsmall
+  defp canonical_size(:s), do: :small
+  defp canonical_size(:m), do: :medium
+  defp canonical_size(:l), do: :large
+  defp canonical_size(:xl), do: :xlarge
+  defp canonical_size(size), do: size
+end

--- a/test/uxid_test.exs
+++ b/test/uxid_test.exs
@@ -32,7 +32,9 @@ defmodule UXIDTest do
       {:ok, decoded_uxid} = UXID.decode("01G2B5M42HWY45WE5YQE3P2CJ2")
 
       assert %UXID.Codec{
+               deterministic: false,
                encoded: "01G2B5M42HWY45WE5YQE3P2CJ2",
+               from: nil,
                prefix: nil,
                rand: :decode_not_supported,
                rand_encoded: "WY45WE5YQE3P2CJ2",


### PR DESCRIPTION
Passing `from:` to generate/1, generate!/1, and new/1 switches on a deterministic (UUIDv5-style) scheme: the same input string always maps to the same ID, across processes and machines.

- Body is a truncated SHA-256 of the input; the prefix is folded in as the namespace, so the same string under two prefixes yields unrelated bodies
- Marked with a leading z/Z (Crockford value 31): self-identifying and sorts after every time-based ID
- Compact-time encoding reserves value 31 so z/Z is an unambiguous marker, trimming the compact horizon to ~mid-2038 (standard 48-bit unaffected)
- decode/1 reports deterministic: true with time: nil; adds deterministic?/1
- from: requires a string; from: with explicit monotonic: true raises; Ecto autogenerate is intentionally not wired (mint explicitly in a changeset)

Includes the guides/deterministic.md guide, README + sizes cross-links, CHANGELOG entry, and a dedicated test suite.