### PR TITLE
Adds deterministic minting through the registry

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,7 +1,7 @@
 # Used by "mix format"
 [
   inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"],
-  # Registry DSL — keep these paren-free, and export the rule so apps that
+  # Registry DSL - keep these paren-free, and export the rule so apps that
   # `use UXID.Registry` format their declarations the same way.
   locals_without_parens: [defid: 1, defid: 2, retired: 1],
   export: [locals_without_parens: [defid: 1, defid: 2, retired: 1]]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,24 +2,33 @@
 
 ## Upcoming
 
+* Makes **deterministic minting reachable through `UXID.Registry`** - 2.7.0 shipped `from:` but the registry's generated `generate!/1` was arity-1 and dropped caller options, so a registry user had to drop to the plain API and hand-assemble prefix/size:
+  - Generated `generate!/2` and `generate/2` merge caller options over the registry's, so `MyApp.IDs.generate!(:export, from: natural_key)` mints deterministically by key; existing arity-1 calls are unchanged
+  - `:prefix` and `:size` belong to the key and raise if overridden - the registry's contract is that a key determines its shape; the intended override surface is `:from`, `:case`, `:monotonic`, `:compact_time`, `:rand_size`
+  - New `defid :export, deterministic: true` declares a key as *always* derived: minting it without `from:` raises, so one call site cannot derive while another mints randomly. It is a requirement, not a permission - an undeclared key may still be minted with `from:`
+  - `deterministic` joins the JSON manifest (as a real boolean) so a Postgres function or JS client knows *which scheme* a key uses; the hash rule itself still comes from the deterministic guide
+  - Ecto `autogenerate` remains unwired for `from:` (no per-row input exists), and the declaration cannot reach it - a `deterministic: true` key must be minted in a changeset, not with `autogenerate: true`
+* Adds `defid :enrichment, legacy: <term>` - opaque app metadata with no library behavior, so a "deliberately still on the old scheme, retrofit deferred" backlog lives in the registry rather than a moduledoc
+* **Breaking:** an unrecognized `defid` option is now a compile error instead of being silently ignored (`defid :org, prefix: "org", validat: false` previously defaulted `validate` to `true` with no warning) - a sharp edge for a registry whose selling point is compile-time checking
+
 ## 2.7.0 / 2026-07-23
 
-* Adds opt-in **deterministic (name-based) IDs** via the `from:` option on `generate/1`, `generate!/1`, and `new/1` — the same input string always maps to the same ID (UUIDv5-style), across processes and machines:
+* Adds opt-in **deterministic (name-based) IDs** via the `from:` option on `generate/1`, `generate!/1`, and `new/1` - the same input string always maps to the same ID (UUIDv5-style), across processes and machines:
   - Body is a truncated **SHA-256** of the input (SHA-256, not the deprecated SHA-1 of real UUIDv5, since no wire interop is needed)
   - The **prefix is the namespace** (folded into the hash), so the same string under two prefixes yields two unrelated bodies; no separate `namespace:` option
   - Marked with a leading `z`/`Z` (Crockford value 31): self-identifying and sorts *after* every time-based ID; not K-sortable among themselves
-  - Reserves value 31 in compact-time encoding so `z`/`Z` is an unambiguous scheme marker — compact timestamps now raise past ~mid-2038 (standard 48-bit timestamps unaffected)
-  - Deterministic bodies reuse the standard (non-compact) lengths per `:size`, spending the whole body (minus the marker) on hash bits (45–125 bits)
+  - Reserves value 31 in compact-time encoding so `z`/`Z` is an unambiguous scheme marker - compact timestamps now raise past ~mid-2038 (standard 48-bit timestamps unaffected)
+  - Deterministic bodies reuse the standard (non-compact) lengths per `:size`, spending the whole body (minus the marker) on hash bits (45-125 bits)
   - `decode/1` reports `deterministic: true` with `time: nil`; adds `UXID.deterministic?/1`
   - `from:` requires a string (raises otherwise); `from:` with an explicit `monotonic: true` raises (deterministic vs. burst-random); Ecto `autogenerate` is intentionally not wired for `from:` (mint explicitly in a changeset)
-  - Not a secret: a hash of a *known* input is exactly as guessable as the input — do not derive an ID from a low-entropy secret and treat it as unguessable
+  - Not a secret: a hash of a *known* input is exactly as guessable as the input - do not derive an ID from a low-entropy secret and treat it as unguessable
 
 ## 2.6.0 / 2026-07-17
 
 * Adds runtime prefix → schema routing for **layered apps**, so a `UXID.Registry` can live at an app's base layer without a `schema:` literal inverting the dependency direction:
-  - New `UXID.Registered` mixin (`use UXID.Registered, key: :contact`) marks a schema under a registry key; the reference points *down* (schema names a key), so the base-layer registry never references an upper-layer module — `Boundary`/`xref` stay clean
-  - `MyApp.IDs.verify!(otp_apps: [...])` / `build_routes!/1` assemble the routing table at boot by scanning the given apps for the marker (via reflection, no compile-visible module reference) and store it in `:persistent_term`; `verify!/1` also validates it — raising on a marker that names an unregistered key, two modules claiming one key, or a `route: true` key left unmapped
-  - Call `verify!/1` from your top app's `start/2` so every boot (prod, dev, CI's `mix test`) re-verifies — no bespoke CI job needed
+  - New `UXID.Registered` mixin (`use UXID.Registered, key: :contact`) marks a schema under a registry key; the reference points *down* (schema names a key), so the base-layer registry never references an upper-layer module - `Boundary`/`xref` stay clean
+  - `MyApp.IDs.verify!(otp_apps: [...])` / `build_routes!/1` assemble the routing table at boot by scanning the given apps for the marker (via reflection, no compile-visible module reference) and store it in `:persistent_term`; `verify!/1` also validates it - raising on a marker that names an unregistered key, two modules claiming one key, or a `route: true` key left unmapped
+  - Call `verify!/1` from your top app's `start/2` so every boot (prod, dev, CI's `mix test`) re-verifies - no bespoke CI job needed
   - `schema_for/1` now resolves a compile-time `schema:` literal first, then the self-registration table, so flat apps are unchanged and layered apps opt in per entry with `route: true`
   - Adds `prefixes/0` (convenience for app-side "every schema draws from the registry" conformance tests) and `routes/0`
 * Restructures the documentation: a slimmed README plus dedicated guides (Sizes & Encoding, Ecto Integration, Monotonic IDs, Prefix Registry, Configuration) that render on both GitHub and HexDocs
@@ -34,19 +43,19 @@
   - Registers `defid`/`retired` as paren-free locals and exports the rule for consuming apps
 * Adds opt-in monotonic generation via the `monotonic` option (per-call/per-field) or `config :uxid, :monotonic` global policy:
   - Accepts `true`/`false`, or a list of sizes (alias-aware, e.g. `[:small]` matches both `:small` and `:s`)
-  - Within a millisecond the random field is seeded once then advanced by a random positive step (uniform over `[1, 2^(bits/2)]`, drawn from the CSPRNG), guaranteeing uniqueness and K-sortability for a burst — process-local, `async: true` safe, no GenServer/ETS
-  - Per-call option takes precedence over the global policy; off by default (consecutive IDs stay in a bounded window — a mitigation, not cryptographic unpredictability — weakening enumeration resistance)
+  - Within a millisecond the random field is seeded once then advanced by a random positive step (uniform over `[1, 2^(bits/2)]`, drawn from the CSPRNG), guaranteeing uniqueness and K-sortability for a burst - process-local, `async: true` safe, no GenServer/ETS
+  - Per-call option takes precedence over the global policy; off by default (consecutive IDs stay in a bounded window - a mitigation, not cryptographic unpredictability - weakening enumeration resistance)
   - `:xs`/`:xsmall` auto-enable `compact_time` so there is a field to increment; explicit `compact_time: false` on those sizes with monotonic on raises
-  - Wire format is byte-identical to a random UXID — no decoder changes
+  - Wire format is byte-identical to a random UXID - no decoder changes
 
 ## 2.4.0 / 2026-07-09
 
 * Adds `UXID.valid?/2` for structural validation of a UXID string (optional `:prefix` and `:delimiter`)
 * Adds opt-in strict casting for the Ecto type via `validate: true` on a field:
   - Accepts a well-formed UXID carrying the field's configured `:prefix`, or a legacy bare UUID string
-  - Rejects malformed values (empty, wrong prefix, non–Base32) with `:error`
+  - Rejects malformed values (empty, wrong prefix, non-Base32) with `:error`
   - UUID coexistence is on by default (eases `uuid` → `text` column migrations); disable with `allow_uuid: false`
-  - Default casting is unchanged (any binary passes) when `validate` is not set — fully backwards compatible
+  - Default casting is unchanged (any binary passes) when `validate` is not set - fully backwards compatible
 * Adds default_delimiter config accessor
 
 ## 2.3.0 / 2026-01-16

--- a/README.md
+++ b/README.md
@@ -7,18 +7,18 @@
 **U**ser e**X**perience focused **ID**entifiers (UXIDs) are prefixed, K-sortable,
 Stripe-style identifiers like `usr_01epey2p06tr1rtv07xa82zgjj`. They are:
 
-* Descriptive — the prefix names the resource on sight (aids debugging and investigation)
-* Copy/paste friendly — double-clicking selects the entire ID
-* Tunable in size — shortened for low-cardinality resources
+* Descriptive - the prefix names the resource on sight (aids debugging and investigation)
+* Copy/paste friendly - double-clicking selects the entire ID
+* Tunable in size - shortened for low-cardinality resources
 * Secure against enumeration attacks
-* Application-generated — not tied to the datastore
-* K-sortable — lexicographically sortable by time, so they index well
-* Coordination-free — no startup or generation-time coordination required
-* Unlikely to collide — more randomness, lower odds
-* Human-transmissible — easy to read out accurately over the phone
-* Optionally **monotonic** — a burst within one millisecond stays unique and strictly ordered
-* Optionally **deterministic** — the same input string always maps to the same ID (UUIDv5-style), marked with a leading `z` and sorted after time-based IDs
-* Optionally **governed by a registry** — one module keeps every prefix unique and maps an ID back to its resource
+* Application-generated - not tied to the datastore
+* K-sortable - lexicographically sortable by time, so they index well
+* Coordination-free - no startup or generation-time coordination required
+* Unlikely to collide - more randomness, lower odds
+* Human-transmissible - easy to read out accurately over the phone
+* Optionally **monotonic** - a burst within one millisecond stays unique and strictly ordered
+* Optionally **deterministic** - the same input string always maps to the same ID (UUIDv5-style), marked with a leading `z` and sorted after time-based IDs
+* Optionally **governed by a registry** - one module keeps every prefix unique and maps an ID back to its resource
 
 Many of the concepts of [Stripe IDs][stripe_ids_url] have been used in this library.
 
@@ -34,7 +34,7 @@ def deps do
 end
 ```
 
-Ecto is an optional dependency — UXID only pulls it in if your app already uses it.
+Ecto is an optional dependency - UXID only pulls it in if your app already uses it.
 
 ## Quick start
 
@@ -59,7 +59,7 @@ UXID.generate!(prefix: "usr", from: "alice@example.com")
 
 ## Ecto in 30 seconds
 
-UXIDs work as Ecto fields, including primary keys — set the field type to `UXID`
+UXIDs work as Ecto fields, including primary keys - set the field type to `UXID`
 and pass the same options you'd pass to `generate!/1`:
 
 ```elixir
@@ -73,19 +73,19 @@ defmodule YourApp.User do
 end
 ```
 
-See the [Ecto Integration guide](guides/ecto.md) for foreign keys, strict
+See the [Ecto Integration guide][guide_ecto_url] for foreign keys, strict
 validation, and migrating a `uuid` column to UXIDs.
 
 ## Guides
 
 The five-minute path is above; each area has a dedicated guide:
 
-* **[Sizes & Encoding](guides/sizes.md)** — the t-shirt sizes, how much randomness each carries, and compact-time mode for extra collision resistance.
-* **[Ecto Integration](guides/ecto.md)** — primary/foreign keys, strict `validate:` casting, `allow_uuid` coexistence, and `UXID.valid?/2`.
-* **[Monotonic IDs](guides/monotonic.md)** — guaranteed same-millisecond uniqueness and ordering, the security tradeoff, and when to use it.
-* **[Deterministic IDs](guides/deterministic.md)** — name-based (UUIDv5-style) IDs where the same input always maps to the same ID, with the prefix as the namespace.
-* **[Prefix Registry](guides/registry.md)** — a compile-time DSL that keeps every prefix unique, routes an ID back to its schema, works in layered/umbrella apps, and exports a cross-source JSON manifest.
-* **[Configuration](guides/configuration.md)** — every `config :uxid` key in one place, with per-call vs. global precedence.
+* **[Sizes & Encoding][guide_sizes_url]** - the t-shirt sizes, how much randomness each carries, and compact-time mode for extra collision resistance.
+* **[Ecto Integration][guide_ecto_url]** - primary/foreign keys, strict `validate:` casting, `allow_uuid` coexistence, and `UXID.valid?/2`.
+* **[Monotonic IDs][guide_monotonic_url]** - guaranteed same-millisecond uniqueness and ordering, the security tradeoff, and when to use it.
+* **[Deterministic IDs][guide_deterministic_url]** - name-based (UUIDv5-style) IDs where the same input always maps to the same ID, with the prefix as the namespace.
+* **[Prefix Registry][guide_registry_url]** - a compile-time DSL that keeps every prefix unique, routes an ID back to its schema, works in layered/umbrella apps, and exports a cross-source JSON manifest.
+* **[Configuration][guide_configuration_url]** - every `config :uxid` key in one place, with per-call vs. global precedence.
 
 ## Documentation
 
@@ -100,6 +100,17 @@ UXID is released under the [MIT License](LICENSE).
 <!-- LINKS -->
 [hex_project_url]: https://hex.pm/packages/uxid
 [hexdocs_project_url]: https://hexdocs.pm/uxid
+
+<!-- Guide links are absolute HexDocs URLs on purpose. A relative link like
+     `guides/registry.md` renders correctly on GitHub and is rewritten to
+     `registry.html` by ExDoc, but hex.pm rewrites it to the raw-file preview
+     (repo.hex.pm/preview/.../registry.md), which serves plain-text Markdown. -->
+[guide_sizes_url]: https://hexdocs.pm/uxid/sizes.html
+[guide_ecto_url]: https://hexdocs.pm/uxid/ecto.html
+[guide_monotonic_url]: https://hexdocs.pm/uxid/monotonic.html
+[guide_deterministic_url]: https://hexdocs.pm/uxid/deterministic.html
+[guide_registry_url]: https://hexdocs.pm/uxid/registry.html
+[guide_configuration_url]: https://hexdocs.pm/uxid/configuration.html
 [mit_license_url]: http://opensource.org/licenses/MIT
 [uxid_talk_url]: https://www.youtube.com/watch?v=YIIJClhjxOA
 [stripe_ids_url]: https://dev.to/stripe/designing-apis-for-humans-object-ids-3o5a

--- a/guides/configuration.md
+++ b/guides/configuration.md
@@ -28,7 +28,7 @@ UXID.generate!(case: :lower)   # => "01emdgjf0dqxqj8fm78xe97y3h"  (per-call over
 ## `:delimiter`
 
 The character placed between the prefix and the body. It must be a character that
-cannot appear in a Crockford Base32 body — `"_"` (the default) or `"-"` — so that
+cannot appear in a Crockford Base32 body - `"_"` (the default) or `"-"` - so that
 prefix parsing stays unambiguous. An underscore keeps double-click-to-select
 working. Override per call with `delimiter:`; a `UXID.Registry` sets it per
 registry with `delimiter:`.
@@ -65,7 +65,7 @@ UXID.generate!(size: :large, compact_time: true)  # opt in for a size the policy
 ## `:monotonic`
 
 Global monotonic policy. Accepts `true` (all sizes), `false`, or a list of sizes
-(alias-aware — `[:small]` matches both `:small` and `:s`). Override per call or
+(alias-aware - `[:small]` matches both `:small` and `:s`). Override per call or
 per field with `monotonic:`. See the [Monotonic IDs guide](monotonic.md) for the
 guarantee and its security tradeoff.
 

--- a/guides/deterministic.md
+++ b/guides/deterministic.md
@@ -1,7 +1,7 @@
 # Deterministic IDs
 
 Standard UXIDs are random: calling `generate!/1` twice with the same options
-gives two different IDs. Deterministic mode is the opposite — **the same input
+gives two different IDs. Deterministic mode is the opposite - **the same input
 string always maps to the same ID**, forever, across processes and machines.
 This is what a name-based UUID (UUIDv5) gives you, adapted to the UXID format.
 
@@ -27,15 +27,36 @@ The ID is a truncated **SHA-256** of the input. `from:` must be a string; pass a
 non-binary and it raises. For a composite key, stringify it yourself first
 (`"#{tenant}:#{email}"`) so you control the exact bytes that get hashed.
 
+## With a prefix registry
+
+If your app has a [prefix registry](registry.md), mint by key rather than
+restating the prefix and size at the call site:
+
+```elixir
+MyApp.IDs.generate!(:export, from: phone)
+```
+
+That is the preferred call shape for registry users: the prefix and size still
+come from the registry (and cannot be overridden), while `from:` passes through.
+Better still, declare the key as always-derived so a random mint becomes
+impossible:
+
+```elixir
+defid :export, prefix: "exp", deterministic: true
+```
+
+See [Deterministic keys](registry.md#deterministic-keys) for the declaration, the
+`autogenerate` caveat, and how the flag travels in the JSON manifest.
+
 ## Prefix is the namespace
 
 The prefix is folded into the hash as the namespace, so the same string under two
-prefixes produces two unrelated bodies — `usr` + `"alice@example.com"` and `org`
+prefixes produces two unrelated bodies - `usr` + `"alice@example.com"` and `org`
 + `"alice@example.com"` never collide:
 
 ```elixir
-UXID.generate!(prefix: "usr", from: "alice@example.com")  # "usr_zcvt7epac…"
-UXID.generate!(prefix: "org", from: "alice@example.com")  # "org_zes4c99fn…"  (unrelated)
+UXID.generate!(prefix: "usr", from: "alice@example.com")  # "usr_zcvt7epac..."
+UXID.generate!(prefix: "org", from: "alice@example.com")  # "org_zes4c99fn..."  (unrelated)
 ```
 
 Most callers pass just `prefix` + `from` and get correct scoping with zero extra
@@ -44,13 +65,13 @@ prefix at all hashes into the global scope.)
 
 ## The `z` marker and sort order
 
-A deterministic body always starts with `z` (or `Z` in upper case) — Crockford
+A deterministic body always starts with `z` (or `Z` in upper case) - Crockford
 value 31, the maximum symbol. It does two jobs:
 
-1. **Self-identifying** — a human or the decoder can see at a glance that the ID
+1. **Self-identifying** - a human or the decoder can see at a glance that the ID
    is hash-derived, not time-derived. `UXID.deterministic?/1` reports it, and
    `decode/1` returns `deterministic: true` with `time: nil`.
-2. **Sorts last** — because `z` is the highest value, every deterministic ID
+2. **Sorts last** - because `z` is the highest value, every deterministic ID
    sorts *after* every time-based ID. They cluster at the end of an index instead
    of interleaving with (and polluting) the K-sortable time range. Among
    themselves they sort in no meaningful order.
@@ -63,7 +84,7 @@ to ~mid-2038 (standard 48-bit timestamps are unaffected). See the
 ## Size and length
 
 Deterministic bodies reuse the standard (non-compact) lengths, spending the whole
-body — minus the one-character marker — on hash bits:
+body - minus the one-character marker - on hash bits:
 
 | Size          | Aliases      | Body length | Hash bits |
 |---------------|--------------|-------------|-----------|
@@ -77,17 +98,17 @@ With no `:size`, generation defaults to `:xl` (125 hash bits). A deterministic I
 carries *more* distinguishing bits than the random UXID of the same size, since it
 does not spend characters on a timestamp. Changing `size` changes the ID: the
 same input at two sizes yields unrelated bodies, not one a truncated prefix of the
-other. Case is a display concern applied at encode time — upper and lower are the
+other. Case is a display concern applied at encode time - upper and lower are the
 same ID, exactly as for random UXIDs.
 
 ## Properties, honestly
 
-- **Deterministic & idempotent** — same `{namespace, name, size, case}` → same ID,
+- **Deterministic & idempotent** - same `{namespace, name, size, case}` → same ID,
   everywhere, forever.
-- **Not time-ordered** — hash order is effectively random-but-stable. These sort
+- **Not time-ordered** - hash order is effectively random-but-stable. These sort
   after time IDs and among themselves in no meaningful order, so do not rely on
   them for K-sortability.
-- **Not a secret** — a deterministic ID is a hash of a *known* input, so it is
+- **Not a secret** - a deterministic ID is a hash of a *known* input, so it is
   exactly as guessable as that input. Anyone who knows the namespace + name can
   recompute the ID. Do **not** derive an ID from a low-entropy secret and treat
   the ID as unguessable. (This is the same caveat RFC 4122 gives for name-based
@@ -100,7 +121,7 @@ same ID, exactly as for random UXIDs.
 
 ## With Ecto
 
-Ecto `autogenerate` is intentionally **not** wired for `from:` — there is no
+Ecto `autogenerate` is intentionally **not** wired for `from:` - there is no
 per-row input available at autogenerate time. Mint the ID explicitly in
 application code (typically a changeset) and store it as an ordinary string:
 
@@ -119,6 +140,10 @@ end
 defp put_deterministic_id(changeset), do: changeset
 ```
 
-The field itself is a normal `UXID` (or `:string`) column — casting and querying
+The field itself is a normal `UXID` (or `:string`) column - casting and querying
 are unchanged; you are just supplying the value instead of letting the datastore
 or `autogenerate` mint a random one.
+
+Note the corollary for registry users: a `deterministic: true` key must **not** be
+wired with `autogenerate: true`, because the declaration cannot reach Ecto's
+autogenerate path and a random ID would be minted there silently.

--- a/guides/ecto.md
+++ b/guides/ecto.md
@@ -1,13 +1,13 @@
 # Ecto Integration
 
 UXID implements `Ecto.ParameterizedType`, so a UXID column is just a `:string`
-(text) column with `UXID` as the field type. Ecto is an optional dependency —
+(text) column with `UXID` as the field type. Ecto is an optional dependency -
 UXID only uses it when your app already depends on it.
 
 ## Fields and primary keys
 
 Set the field type to `UXID` and pass the same options you'd give
-`UXID.generate!/1` (`:prefix`, `:size`, `:compact_time`, `:monotonic`, …).
+`UXID.generate!/1` (`:prefix`, `:size`, `:compact_time`, `:monotonic`, ...).
 `autogenerate: true` mints a value on insert when the field is blank.
 
 ```elixir
@@ -49,7 +49,7 @@ still holds a mix of legacy identifiers. Opt a field into strict validation with
 - a structurally valid UXID carrying the field's configured `:prefix`, or
 - a legacy bare UUID string (canonical 36-character form).
 
-Anything else — an empty string, the wrong prefix, non–Base32 characters — casts
+Anything else - an empty string, the wrong prefix, non-Base32 characters - casts
 to `:error`.
 
 ```elixir
@@ -82,6 +82,6 @@ UXID.valid?("not-a-uxid")                                     # => false
 ```
 
 It validates structure, not authenticity, and deliberately does **not** accept
-bare UUIDs — that coexistence lives only in `cast/2`. To centralize the
+bare UUIDs - that coexistence lives only in `cast/2`. To centralize the
 `prefix`/`size`/`validate`/`allow_uuid` options for a field so they live in one
 place, see the [Prefix Registry guide](registry.md) and its `field_opts/1` hook.

--- a/guides/monotonic.md
+++ b/guides/monotonic.md
@@ -1,19 +1,19 @@
 # Monotonic IDs
 
 Standard UXIDs draw fresh randomness for every ID, so collision risk within a
-single millisecond is a birthday problem — for small sizes (`:xsmall` has 0
+single millisecond is a birthday problem - for small sizes (`:xsmall` has 0
 random bits, `:small` has 16) a burst of same-millisecond IDs can collide.
 Monotonic mode fixes this the way the ULID monotonic spec does: within a
 millisecond it seeds the random field once from the CSPRNG, then advances it by a
 **random positive step** for each subsequent ID. That turns "birthday collision
 among N draws" into "guaranteed distinct until the field overflows," and because
 the field is encoded big-endian, a strictly increasing counter also sorts
-strictly after — K-sortability is preserved at every size.
+strictly after - K-sortability is preserved at every size.
 
 The step is uniform over `[1, 2^(bits/2)]` (the square root of the field space,
-auto-derived from the size — no configuration). Stepping by a random amount
-instead of exactly `+1` means an attacker who sees `…0004` can no longer guess
-`…0005`: single-shot guess cost rises from certainty to `~1/2^(bits/2)` (1/256 at
+auto-derived from the size - no configuration). Stepping by a random amount
+instead of exactly `+1` means an attacker who sees `...0004` can no longer guess
+`...0005`: single-shot guess cost rises from certainty to `~1/2^(bits/2)` (1/256 at
 `:small`, ~1/10⁶ at `:medium`), while still leaving ample same-ms burst headroom
 before overflow (~512 IDs/ms at `:small`, ~2M at `:medium`).
 
@@ -45,7 +45,7 @@ field :id, UXID, autogenerate: true, prefix: "evt", size: :small, monotonic: tru
 ## Scope of the guarantee
 
 Monotonic and collision-free *within a single BEAM process*. State lives in the
-process dictionary (keyed by prefix and field size) — no GenServer, no ETS, no
+process dictionary (keyed by prefix and field size) - no GenServer, no ETS, no
 shared state, so it is `async: true` safe. Each process gets an independent
 random starting point per millisecond, so cross-process collisions fall back to a
 birthday probability on the field size.
@@ -65,11 +65,11 @@ choice and is never a silent default.
 
 ## `:xs` / `:xsmall` note
 
-A standard `:xs` has 0 random bits — nothing to increment — so when monotonic is
+A standard `:xs` has 0 random bits - nothing to increment - so when monotonic is
 active `compact_time` is enabled automatically for `:xs`/`:xsmall`, yielding a
 1-byte (8-bit) counter field. Passing an explicit `compact_time: false` on
 `:xs`/`:xsmall` with monotonic on raises an `ArgumentError` (there would be no
 field to count). This inherits the compact `:xsmall` time-decode ambiguity
-described in the [Sizes & Encoding guide](sizes.md#compact-time) — uniqueness and
+described in the [Sizes & Encoding guide](sizes.md#compact-time) - uniqueness and
 sorting are unaffected, but decoding the timestamp back out of a monotonic `:xs`
 is unreliable.

--- a/guides/registry.md
+++ b/guides/registry.md
@@ -1,6 +1,6 @@
 # Prefix Registry
 
-A prefix only pays off — "the ID names its resource on sight" — when it is
+A prefix only pays off - "the ID names its resource on sight" - when it is
 globally unique and well-formed across your whole app. `UXID.Registry` is an
 opt-in, compile-time DSL that makes those guarantees the compiler's job instead
 of a hand-rolled CI test, and turns the same declarations into a runtime routing
@@ -27,55 +27,121 @@ end
 
 **Compile-time guarantees.** Every prefix is checked against `:prefix_format`
 (overridable; the default permits an internal underscore for compound prefixes
-like `in_ref`), and all prefixes — active *and* `retired` — are checked for
+like `in_ref`), and all prefixes - active *and* `retired` - are checked for
 uniqueness. A malformed or duplicate prefix is a compile error, so the governance
 every prefixed-ID scheme needs ships in the library.
 
 Keep to **one registry module per app**: compile-time uniqueness only holds
 within a single module, since the library never sees two registries together.
 
-## By key — minting and schema configuration
+## By key - minting and schema configuration
 
 ```elixir
-MyApp.IDs.generate!(:org)   # => "org_01h…"
+MyApp.IDs.generate!(:org)   # => "org_01h..."
 MyApp.IDs.prefix(:org)      # => "org"
 MyApp.IDs.size(:org)        # => :medium
 MyApp.IDs.schema(:org)      # => MyApp.Org
 MyApp.IDs.all()             # => [%{key: :org, prefix: "org", schema: MyApp.Org, ...}, ...]
 ```
 
-`field_opts/1` is the single-source-of-truth hook — a schema spreads it instead
+`field_opts/1` is the single-source-of-truth hook - a schema spreads it instead
 of restating prefix/size/validate anywhere:
 
 ```elixir
 @primary_key {:id, UXID, [autogenerate: true] ++ MyApp.IDs.field_opts(:org)}
 ```
 
-## By ID string — the runtime routing table
+`generate!/2` merges caller options over the registry's, so a call site can pass
+anything the key does not own:
+
+```elixir
+MyApp.IDs.generate!(:share, monotonic: false)   # one-off override
+MyApp.IDs.generate!(:export, from: natural_key) # deterministic - see below
+```
+
+`:prefix` and `:size` belong to the key and raise if passed - the registry's whole
+contract is that a key determines its shape. Drop to `UXID.generate!/1` if you
+genuinely need a one-off shape.
+
+## Deterministic keys
+
+Some entities are derived rather than created: their identity is a function of a
+natural key, so the same input must always produce the same ID (see the
+[Deterministic IDs guide](deterministic.md)). Mint those by key with `from:`:
+
+```elixir
+MyApp.IDs.generate!(:export, from: phone)
+# => "exp_z9r3k..."   (stable for this input, forever)
+```
+
+Passthrough alone still permits the failure mode where one call site derives and
+another mints randomly, silently producing two ID shapes for one entity. Declare
+the key so that becomes impossible:
+
+```elixir
+defid :export, prefix: "exp", deterministic: true, route: true
+```
+
+```elixir
+MyApp.IDs.generate!(:export)
+# ** (ArgumentError) key :export is declared deterministic: true and must be
+#    minted with from: - e.g. generate!(:export, from: natural_key)
+```
+
+The flag is a *requirement*, not a permission: an undeclared key can still be
+minted with `from:`, so an incidental deterministic ID does not force a registry
+change.
+
+**Do not wire a deterministic key with `autogenerate: true`.** Ecto has no
+per-row input at autogenerate time, so `UXID` mints a random ID there and the
+declaration cannot stop it. Mint in a changeset instead:
+
+```elixir
+# NOT this, for a deterministic key:
+@primary_key {:id, UXID, [autogenerate: true] ++ MyApp.IDs.field_opts(:export)}
+
+# but this:
+@primary_key {:id, UXID, MyApp.IDs.field_opts(:export)}
+
+def changeset(export, attrs) do
+  export
+  |> cast(attrs, [:phone])
+  |> put_change(:id, MyApp.IDs.generate!(:export, from: attrs.phone))
+end
+```
+
+The flag is surfaced on `all/0`, so an app can enforce that rule over its own
+registry in a conformance test.
+
+One sizing note: a deterministic body spends its whole width on hash bits, and a
+key with no `:size` (and no registry `:default_size`) falls through to the
+**`:xlarge`** width - set `:size` explicitly if you want narrower derived IDs.
+
+## By ID string - the runtime routing table
 
 This is the "which resource is this?" map that powers authorization scans, admin
 tooling, and global-ID resolution:
 
 ```elixir
-MyApp.IDs.known?("org_01h…")      # => true   (cheap prefix-only membership check)
-MyApp.IDs.key_for("org_01h…")     # => :org
-MyApp.IDs.schema_for("org_01h…")  # => MyApp.Org
-MyApp.IDs.resolve("org_01h…")     # => %{key: :org, schema: MyApp.Org, category: :account, ...}
+MyApp.IDs.known?("org_01h...")      # => true   (cheap prefix-only membership check)
+MyApp.IDs.key_for("org_01h...")     # => :org
+MyApp.IDs.schema_for("org_01h...")  # => MyApp.Org
+MyApp.IDs.resolve("org_01h...")     # => %{key: :org, schema: MyApp.Org, category: :account, ...}
 ```
 
 Lookups split an ID on the **last** delimiter, which is unambiguous without any
 registry lookup because a UXID body is Crockford Base32 and never contains the
-delimiter — so `in_ref_01h…` recovers the `in_ref` prefix cleanly. For that
+delimiter - so `in_ref_01h...` recovers the `in_ref` prefix cleanly. For that
 reason the `:delimiter` must be a character that cannot appear in a Base32 body
-(`"_"` — the default — or `"-"`); an underscore is preferred for compound
+(`"_"` - the default - or `"-"`); an underscore is preferred for compound
 prefixes since it does not break double-click-to-select-the-whole-id.
 
 ## Routing in a layered or umbrella app
 
 The `schema:` literal above points the registry **up** at a schema module. In a
 flat app that is fine. But in a layered app the registry usually wants to live at
-the *base* layer — so every layer can depend down on it to mint IDs and read
-`field_opts/1` — while the schemas it routes to live *above* it. Naming those
+the *base* layer - so every layer can depend down on it to mint IDs and read
+`field_opts/1` - while the schemas it routes to live *above* it. Naming those
 schemas from the base layer inverts the dependency direction (and trips tools
 like `Boundary`).
 
@@ -84,13 +150,13 @@ itself under its key with `UXID.Registered`. The reference then points *down*
 (schema names a registry key), never up:
 
 ```elixir
-# base layer — governance only, no schema: literal
+# base layer - governance only, no schema: literal
 defmodule MyApp.IDs do
   use UXID.Registry
   defid :contact, prefix: "contact", route: true   # filled at boot by self-registration
 end
 
-# upper layer — the schema marks itself
+# upper layer - the schema marks itself
 defmodule MyApp.CRM.Contact do
   use Ecto.Schema
   use UXID.Registered, key: :contact
@@ -104,10 +170,10 @@ not required).
 
 ### Building and verifying the table at boot
 
-At boot, `verify!/1` scans the given OTP apps for the marker (by reflection — no
+At boot, `verify!/1` scans the given OTP apps for the marker (by reflection - no
 base-layer reference to an upper-layer module), assembles the prefix → schema
 table into `:persistent_term`, and validates it. Wire it into your top app's
-`start/2` so **every** boot — prod, dev, and CI's `mix test` — re-verifies:
+`start/2` so **every** boot - prod, dev, and CI's `mix test` - re-verifies:
 
 ```elixir
 def start(_type, _args) do
@@ -123,12 +189,12 @@ end
 - a `route: true` key resolves to no schema.
 
 After it runs, `schema_for/1` resolves layered schemas from the table (flat-app
-`schema:` literals resolve with no build at all — `schema_for/1` checks the
+`schema:` literals resolve with no build at all - `schema_for/1` checks the
 literal first, then the table).
 
 ## Verifying uniqueness & correctness in CI
 
-You don't need a bespoke CI job — CI already boots your app when it runs
+You don't need a bespoke CI job - CI already boots your app when it runs
 `mix test`, and `verify!/1` in `start/2` runs on that boot. Between the compiler
 and `verify!/1` you get:
 
@@ -139,7 +205,7 @@ and `verify!/1` you get:
 
 The one thing the library can't know is "every schema actually draws its id from
 the registry." That stays an app-side test. With `prefixes/0` and two small
-reflection helpers it's a handful of lines — discover every UXID-keyed schema in
+reflection helpers it's a handful of lines - discover every UXID-keyed schema in
 your app and assert each prefix is registered:
 
 ```elixir
@@ -177,17 +243,18 @@ end
 
 ## Sharing the registry across sources (JSON manifest)
 
-UXIDs are source-agnostic — you can mint them in Postgres with `INSERT ... SELECT`
+UXIDs are source-agnostic - you can mint them in Postgres with `INSERT ... SELECT`
 or on a mobile/JS client that generates an ID offline before upload. To keep the
 Elixir registry the single source of truth in those places too, export a JSON
 manifest and let the other runtime read it:
 
 ```elixir
 MyApp.IDs.manifest()
-# => [%{"key" => "org", "prefix" => "org", "size" => "medium", "category" => "account"}, ...]
+# => [%{"key" => "org", "prefix" => "org", "size" => "medium",
+#       "category" => "account", "deterministic" => false}, ...]
 
 MyApp.IDs.manifest_json()
-# => ~s([{"key":"org","prefix":"org","size":"medium","category":"account"}, ...])
+# => ~s([{"key":"org","prefix":"org","size":"medium","category":"account","deterministic":false}, ...])
 ```
 
 `manifest/0` returns plain JSON-safe data (string keys, scalar values, `nil` for
@@ -208,8 +275,15 @@ end
 ```
 
 The manifest carries `prefix`, `size` (which fixes the random length), `category`,
-and `key`; combine each `prefix` with the registry's delimiter and a Base32 body
-to assemble an ID anywhere.
+`key`, and `deterministic`; combine each `prefix` with the registry's delimiter and
+a Base32 body to assemble an ID anywhere.
+
+`deterministic` tells another generator *which scheme* a key uses, not how to
+implement it - a generator that ignored the flag would mint a random ID for a
+derived key, which is exactly the cross-source drift the manifest exists to
+prevent. Reproducing the scheme itself (SHA-256 over prefix + input, the `z`
+marker, the hash-char table) is on the implementer; see the
+[Deterministic IDs guide](deterministic.md).
 
 <!-- LINKS -->
 [uxid_talk_url]: https://www.youtube.com/watch?v=YIIJClhjxOA

--- a/guides/sizes.md
+++ b/guides/sizes.md
@@ -8,7 +8,7 @@ matters.
 
 ## T-shirt sizes
 
-Pass `:size` as a t-shirt size — either the short or long alias:
+Pass `:size` as a t-shirt size - either the short or long alias:
 
 | Size          | Aliases      | Random bits | Body length |
 |---------------|--------------|-------------|-------------|
@@ -18,7 +18,7 @@ Pass `:size` as a t-shirt size — either the short or long alias:
 | `:l`          | `:large`     | 56          | 22 chars    |
 | `:xl`         | `:xlarge`    | 80          | 26 chars    |
 
-Body length excludes the prefix and delimiter — `cus_` adds four more characters.
+Body length excludes the prefix and delimiter - `cus_` adds four more characters.
 With no `:size`, generation defaults to 80 random bits (the same as `:xl`).
 
 ```elixir
@@ -28,7 +28,7 @@ UXID.generate!(prefix: "cus", size: :xl)      # "cus_01kxr2jnqndq7qx9wrvhmrzrhw"
 
 [Deterministic IDs](deterministic.md) reuse these same body lengths, but spend
 the whole body (minus the one-character `z`/`Z` marker) on hash bits instead of a
-timestamp plus randomness — so a deterministic `:m` body is 85 hash bits, not 40.
+timestamp plus randomness - so a deterministic `:m` body is 85 hash bits, not 40.
 
 ## Collision resistance
 
@@ -51,7 +51,7 @@ mint before the odds cross ~1%:
 | `:l`       | 56          | ~7.2 × 10¹⁶            | ~38 million                   |
 | `:xl`      | 80          | ~1.2 × 10²⁴            | ~150 billion                  |
 
-The numbers are per millisecond and per independent generator — spread the same
+The numbers are per millisecond and per independent generator - spread the same
 burst across processes or nodes and the same-millisecond draws still share the
 space, so the birthday math spans all of them together.
 
@@ -68,18 +68,18 @@ space, so the birthday math spans all of them together.
 If you need a small ID *and* a high same-millisecond burst rate, enable
 [monotonic mode](monotonic.md). Instead of drawing fresh randomness for every ID
 (the birthday problem above), it seeds the random field once per millisecond and
-then advances it by a random positive step for each subsequent ID — so
+then advances it by a random positive step for each subsequent ID - so
 same-millisecond IDs from one process are **guaranteed distinct** (and strictly
 ordered) rather than merely unlikely to collide. That turns the `~36`
 same-ms budget at `:small` into the full field range before overflow (~512 IDs/ms
-at `:small`, ~2M at `:medium`). It has a security tradeoff and is process-local —
+at `:small`, ~2M at `:medium`). It has a security tradeoff and is process-local -
 see the [Monotonic IDs guide](monotonic.md) for the full picture.
 
 ## Compact time
 
 Standard UXIDs use a 48-bit timestamp (10 characters). Compact-time mode drops
 that to a 40-bit timestamp (8 characters) and hands the freed 8 bits to the
-random field — more collision resistance, often in *fewer* characters:
+random field - more collision resistance, often in *fewer* characters:
 
 ```elixir
 UXID.generate!(size: :small)                     # 14-char body, 16 random bits
@@ -87,14 +87,14 @@ UXID.generate!(size: :small, compact_time: true) # 13-char body, 24 random bits
 ```
 
 - Reduces the timestamp from 48 bits (10 chars) to 40 bits (8 chars).
-- Frees 8 bits for randomness — e.g. `:small` gains 50% more (24 vs 16 bits).
+- Frees 8 bits for randomness - e.g. `:small` gains 50% more (24 vs 16 bits).
 - Keeps perfect 5-bit Crockford Base32 alignment.
 - Stays K-sortable until ~mid-2038, after which the compact encoder raises: value 31 (the first char `z`/`Z`) is reserved as the [deterministic-ID](deterministic.md) scheme marker, so no compact timestamp may emit it. Standard 48-bit timestamps are unaffected.
 - The decoder auto-detects the compact format from the length and reconstructs the full timestamp.
 
 Compact time is useful for test suites that mint IDs rapidly and for small
 resources that need better collision resistance without growing longer. Enable it
-per call (`compact_time: true`), per Ecto field, or globally for small sizes —
+per call (`compact_time: true`), per Ecto field, or globally for small sizes -
 see the [Configuration guide](configuration.md).
 
 ## Enforcing a minimum size

--- a/lib/uxid.ex
+++ b/lib/uxid.ex
@@ -13,7 +13,7 @@ defmodule UXID do
   * Do not require any coordination (human or automated) at startup, or generation
   * Are very unlikely to collide (more likely with less randomness)
   * Are easily and accurately transmitted to another human using a telephone
-  * Can optionally be deterministic (name-based) — the same input always maps to
+  * Can optionally be deterministic (name-based) - the same input always maps to
     the same ID
 
   Many of the concepts of Stripe IDs have been used in this library.
@@ -24,7 +24,7 @@ defmodule UXID do
   deterministic (name-based) ID: the same input string always maps to the same
   ID (UUIDv5-style), with the prefix acting as the namespace. Deterministic IDs
   carry a leading `z`/`Z` marker and sort after time-based IDs. They are a hash
-  of a *known* input, so they are not unguessable — see `generate/1` and the
+  of a *known* input, so they are not unguessable - see `generate/1` and the
   Deterministic IDs guide for the full picture.
   """
 
@@ -73,11 +73,11 @@ defmodule UXID do
 
   Deterministic IDs are marked with a leading `z`/`Z` and sort *after* every
   time-based ID; they are not K-sortable among themselves. They are a hash of a
-  *known* input, so they are exactly as guessable as that input — do not derive
+  *known* input, so they are exactly as guessable as that input - do not derive
   an ID from a low-entropy secret and treat the ID as unguessable.
 
       {:ok, id} = UXID.generate(prefix: "usr", from: "alice@example.com")
-      # {:ok, "usr_z…"} — identical for this input on every call
+      # {:ok, "usr_z..."} - identical for this input on every call
 
   """
   def generate(opts \\ []) do
@@ -95,7 +95,7 @@ defmodule UXID do
   for the full deterministic-mode notes.
 
       UXID.generate!(prefix: "usr", from: "alice@example.com")
-      # => "usr_z…" (stable for this input, forever)
+      # => "usr_z..." (stable for this input, forever)
 
   """
   def generate!(opts \\ []) do
@@ -142,7 +142,7 @@ defmodule UXID do
     do:
       raise(
         ArgumentError,
-        "from: must be a string, got: #{inspect(other)} — stringify your key before passing it"
+        "from: must be a string, got: #{inspect(other)} - stringify your key before passing it"
       )
 
   def encode_case(), do: Application.get_env(:uxid, :case, :lower)
@@ -180,8 +180,8 @@ defmodule UXID do
   ID in a millisecond is seeded from the CSPRNG and each subsequent same-ms ID
   advances it by a random positive step (per process, per prefix). This
   guarantees uniqueness and K-sortability within a burst while keeping
-  consecutive IDs within a bounded window ahead — a mitigation, not cryptographic
-  unpredictability — which is why it is off by default and opt-in per resource.
+  consecutive IDs within a bounded window ahead - a mitigation, not cryptographic
+  unpredictability - which is why it is off by default and opt-in per resource.
 
   Accepts `true`/`false`, or a list of sizes (alias-aware, e.g. `[:small]`
   matches both `:small` and `:s`). Overridable per-call/per-field with the
@@ -248,7 +248,7 @@ defmodule UXID do
 
   Deterministic IDs carry a leading `z`/`Z` scheme marker (Crockford value 31)
   instead of an encoded timestamp, so this only inspects the first body
-  character — it does not otherwise validate structure (pair it with `valid?/2`
+  character - it does not otherwise validate structure (pair it with `valid?/2`
   if you need both). Time-based IDs start with a lower value and return `false`.
 
   ## Options
@@ -299,7 +299,7 @@ defmodule UXID do
   end
 
   # Only ever called on a binary (cast_strict/2 guards is_binary before calling),
-  # so no non-binary clause is needed — the guard documents that contract.
+  # so no non-binary clause is needed - the guard documents that contract.
   defp uuid_string?(term) when is_binary(term), do: Regex.match?(@uuid_format, term)
 
   # Define additional functions for custom Ecto type if Ecto is loaded
@@ -314,7 +314,7 @@ defmodule UXID do
 
         field :id, UXID, autogenerate: true, prefix: "evt", size: :small, monotonic: true
 
-    Deterministic (`from:`) IDs are intentionally **not** wired here — there is no
+    Deterministic (`from:`) IDs are intentionally **not** wired here - there is no
     per-row input available at autogenerate time. Mint them explicitly in
     application code (e.g. in a changeset via `generate!/1`) and store/cast the
     result as an ordinary string.

--- a/lib/uxid/decoder.ex
+++ b/lib/uxid/decoder.ex
@@ -110,7 +110,7 @@ defmodule UXID.Decoder do
 
   # Decode UXID and extract timestamp
   @spec decode_time(Codec.t()) :: Codec.t()
-  # Deterministic (name-based) IDs carry a hash, not a timestamp — do not decode
+  # Deterministic (name-based) IDs carry a hash, not a timestamp - do not decode
   # the body as time.
   def decode_time(%Codec{deterministic: true} = struct), do: %{struct | time: nil}
 

--- a/lib/uxid/encoder.ex
+++ b/lib/uxid/encoder.ex
@@ -194,7 +194,7 @@ defmodule UXID.Encoder do
 
   defp ensure_rand_size(uxid), do: uxid
 
-  # Explicit compact_time: false on :xs/:xsmall leaves 0 random bits — the only
+  # Explicit compact_time: false on :xs/:xsmall leaves 0 random bits - the only
   # way to reach monotonic with no field to increment. That is a genuine
   # contradiction; raise rather than silently emit a non-incrementing ID.
   defp ensure_rand(%Codec{monotonic: true, rand_size: 0}),
@@ -202,7 +202,7 @@ defmodule UXID.Encoder do
       raise(
         ArgumentError,
         "monotonic mode needs a random field, but compact_time: false on :xs/:xsmall " <>
-          "leaves none — omit compact_time (it is enabled automatically) or use a larger size"
+          "leaves none - omit compact_time (it is enabled automatically) or use a larger size"
       )
 
   defp ensure_rand(
@@ -228,14 +228,14 @@ defmodule UXID.Encoder do
 
   defp ensure_delimiter(uxid), do: uxid
 
-  # from: (deterministic) and an explicit monotonic: true are a contradiction —
+  # from: (deterministic) and an explicit monotonic: true are a contradiction -
   # one asks for a stable hash, the other for burst-unique randomness. The global
   # monotonic policy is not consulted on this path; only an explicit true conflicts.
   defp reject_monotonic_conflict(%Codec{monotonic: true}),
     do:
       raise(
         ArgumentError,
-        "from: (deterministic mode) and monotonic: true are mutually exclusive — " <>
+        "from: (deterministic mode) and monotonic: true are mutually exclusive - " <>
           "a deterministic ID is a stable hash, not burst-random"
       )
 
@@ -313,7 +313,7 @@ defmodule UXID.Encoder do
     if truncated_time >>> 35 == 31 do
       raise ArgumentError,
             "compact_time cannot encode timestamps at/after ~mid-2038: value 31 is " <>
-              "reserved as the deterministic-ID scheme marker — use a standard size"
+              "reserved as the deterministic-ID scheme marker - use a standard size"
     end
 
     string = encode_time_compact(<<truncated_time::unsigned-size(40)>>, case)

--- a/lib/uxid/monotonic.ex
+++ b/lib/uxid/monotonic.ex
@@ -2,24 +2,24 @@ defmodule UXID.Monotonic do
   @moduledoc """
   Process-local monotonic counter backing UXID's `monotonic:` mode.
 
-  All state lives in the process dictionary — no GenServer, no ETS, no shared
-  state — so callers stay `async: true` safe. Each BEAM process maintains its
+  All state lives in the process dictionary - no GenServer, no ETS, no shared
+  state - so callers stay `async: true` safe. Each BEAM process maintains its
   own independent sequence per `{prefix, rand_size}`.
 
   The random field is treated as one big-endian unsigned integer. The first ID
   in a given millisecond seeds it with full CSPRNG bytes; each subsequent ID in
   the same millisecond advances it by a random positive step drawn from the
   CSPRNG. Because the step is always `>= 1` the sequence is strictly increasing,
-  so IDs stay unique and — since the encoding is big-endian and the Crockford
-  alphabet is ASCII-monotonic — integer order equals encoded lexical order,
+  so IDs stay unique and - since the encoding is big-endian and the Crockford
+  alphabet is ASCII-monotonic - integer order equals encoded lexical order,
   preserving K-sortability within the millisecond.
 
   The step is uniform over `[1, 2^(bits/2)]` where `bits` is the field width, so
   the next value is spread across a window of size `~2^(bits/2)` instead of being
   exactly `+1`. This is a *mitigation, not cryptographic unpredictability*: it
-  removes trivial `…0004` → `…0005` enumeration and raises single-shot guess cost
+  removes trivial `...0004` → `...0005` enumeration and raises single-shot guess cost
   from certainty to `~1/2^(bits/2)`, but consecutive values still lie in a bounded
-  window ahead. Low-entropy sizes (`:small` = 16 bits) remain low-entropy — don't
+  window ahead. Low-entropy sizes (`:small` = 16 bits) remain low-entropy - don't
   use small/medium monotonic IDs as externally-enumerable, security-sensitive
   identifiers.
   """

--- a/lib/uxid/registered.ex
+++ b/lib/uxid/registered.ex
@@ -2,7 +2,7 @@ defmodule UXID.Registered do
   @moduledoc """
   Marks a module (typically an Ecto schema) as belonging to a `UXID.Registry`
   key, so the registry can assemble its runtime prefix → schema routing table by
-  reflection at boot — *without* the base-layer registry ever naming the
+  reflection at boot - *without* the base-layer registry ever naming the
   upper-layer schema module in code.
 
       defmodule MyApp.CRM.Contact do
@@ -12,8 +12,8 @@ defmodule UXID.Registered do
       end
 
   This defines `__uxid_key__/0`, the marker that `MyApp.IDs.build_routes!/1` /
-  `verify!/1` collect. Every reference points **down** — the schema names a
-  registry *key*, never the reverse — so a layered app keeps the correct
+  `verify!/1` collect. Every reference points **down** - the schema names a
+  registry *key*, never the reverse - so a layered app keeps the correct
   dependency direction: the registry can live at the base layer while the
   schemas it routes to live above it. See `UXID.Registry` for the routing and
   boot-verification story.

--- a/lib/uxid/registry.ex
+++ b/lib/uxid/registry.ex
@@ -2,7 +2,7 @@ defmodule UXID.Registry do
   @moduledoc """
   A compile-time registry of an application's UXID prefixes.
 
-  Prefixes only deliver their value — "the ID names its resource on sight" — if
+  Prefixes only deliver their value - "the ID names its resource on sight" - if
   they are globally unique and well-formed across an app. `use UXID.Registry`
   moves that governance out of hand-rolled CI tests and into the compiler, and
   turns the same declarations into a runtime routing table (prefix → schema)
@@ -26,9 +26,9 @@ defmodule UXID.Registry do
 
   ## Compile-time guarantees
 
-    * every `:prefix` is checked against `:prefix_format` — a malformed prefix is
+    * every `:prefix` is checked against `:prefix_format` - a malformed prefix is
       a compile error;
-    * all prefixes (active *and* `retired`) are checked for uniqueness — a
+    * all prefixes (active *and* `retired`) are checked for uniqueness - a
       duplicate is a compile error. This replaces the per-app runtime uniqueness
       test.
 
@@ -36,39 +36,44 @@ defmodule UXID.Registry do
 
   By key (minting and schema configuration):
 
-      MyApp.IDs.generate!(:org)   # => "org_01h…"
+      MyApp.IDs.generate!(:org)   # => "org_01h..."
+      MyApp.IDs.generate!(:export, from: phone)  # deterministic - see generate!/2
       MyApp.IDs.prefix(:org)      # => "org"
       MyApp.IDs.size(:org)        # => :medium
       MyApp.IDs.schema(:org)      # => MyApp.Org
       MyApp.IDs.field_opts(:org)  # => [prefix: "org", size: :medium, validate: true, allow_uuid: true, delimiter: "_"]
       MyApp.IDs.all()             # => [%{key: :org, prefix: "org", ...}, ...]
 
-  Cross-source single source of truth — emit a JSON manifest so a database
+  Cross-source single source of truth - emit a JSON manifest so a database
   function or a mobile/JS generator mints prefixes the same way the app does:
 
       MyApp.IDs.manifest()        # => [%{"key" => "org", "prefix" => "org", "size" => "medium", ...}]
-      MyApp.IDs.manifest_json()   # => ~s([{"key":"org","prefix":"org","size":"medium","category":"account"},...])
+      MyApp.IDs.manifest_json()   # => ~s([{"key":"org",...,"category":"account","deterministic":false},...])
 
-  `field_opts/1` is the single-source-of-truth hook — a schema spreads it instead
+  The manifest's `deterministic` flag tells a non-Elixir generator *which scheme*
+  a key uses, not how to implement it - see `guides/deterministic.md` for the
+  hash rule such a generator must reproduce.
+
+  `field_opts/1` is the single-source-of-truth hook - a schema spreads it instead
   of restating anything:
 
       @primary_key {:id, UXID, [autogenerate: true] ++ MyApp.IDs.field_opts(:org)}
 
-  By ID string (runtime routing — see "Parsing" below):
+  By ID string (runtime routing - see "Parsing" below):
 
-      MyApp.IDs.known?("org_01h…")      # => true   (cheap prefix-only membership)
-      MyApp.IDs.key_for("org_01h…")     # => :org
-      MyApp.IDs.schema_for("org_01h…")  # => MyApp.Org
-      MyApp.IDs.resolve("org_01h…")     # => %{key: :org, schema: MyApp.Org, ...}
+      MyApp.IDs.known?("org_01h...")      # => true   (cheap prefix-only membership)
+      MyApp.IDs.key_for("org_01h...")     # => :org
+      MyApp.IDs.schema_for("org_01h...")  # => MyApp.Org
+      MyApp.IDs.resolve("org_01h...")     # => %{key: :org, schema: MyApp.Org, ...}
 
   ## Parsing
 
   Lookups split an ID into `{prefix, body}` on the **last** delimiter. This is
   unambiguous without consulting the registry, because a UXID body is Crockford
-  Base32 and therefore never contains the delimiter: in `in_ref_01h…` every `_`
+  Base32 and therefore never contains the delimiter: in `in_ref_01h...` every `_`
   belongs to the prefix except the final joining one. The registry is consulted
-  only *after* the split, to answer membership/type — an unregistered but
-  well-formed string like `nope_01h…` parses fine yet resolves to `nil`.
+  only *after* the split, to answer membership/type - an unregistered but
+  well-formed string like `nope_01h...` parses fine yet resolves to `nil`.
 
   Because of that, the `:delimiter` must be a character that cannot appear in a
   Base32 body (`"_"` or `"-"`); a letter or digit is rejected at compile time.
@@ -81,7 +86,7 @@ defmodule UXID.Registry do
   that is fine, and `schema_for/1` resolves it with no further setup. In a
   **layered** app the registry usually lives at the base layer (so every layer
   can depend down on it to mint IDs and read `field_opts/1`), while the schemas
-  it routes to live above it — so naming them inverts the dependency direction.
+  it routes to live above it - so naming them inverts the dependency direction.
 
   To keep the direction correct, omit `schema:` and let each schema register
   itself under its key with `UXID.Registered`. The reference then points *down*
@@ -99,7 +104,7 @@ defmodule UXID.Registry do
       end
 
   At boot, `verify!/1` scans the given OTP apps for the marker, assembles the
-  prefix → schema routing table into `:persistent_term`, and validates it —
+  prefix → schema routing table into `:persistent_term`, and validates it -
   raising if a marker names an unregistered key, two modules claim one key, or a
   `route: true` key resolves to no schema. Wire it into your top app's `start/2`
   so every boot (prod, dev, and CI's `mix test`) re-verifies:
@@ -128,11 +133,11 @@ defmodule UXID.Registry do
   Splits a UXID string into `{prefix, body}` on the last occurrence of
   `delimiter`. Returns `{nil, string}` when the delimiter is absent.
 
-      iex> UXID.Registry.split_last("in_ref_01h2x…", "_")
-      {"in_ref", "01h2x…"}
+      iex> UXID.Registry.split_last("in_ref_01h2x...", "_")
+      {"in_ref", "01h2x..."}
 
-      iex> UXID.Registry.split_last("01h2x…", "_")
-      {nil, "01h2x…"}
+      iex> UXID.Registry.split_last("01h2x...", "_")
+      {nil, "01h2x..."}
   """
   @spec split_last(String.t(), String.t()) :: {String.t() | nil, String.t()}
   def split_last(string, delimiter) when is_binary(string) and is_binary(delimiter) do
@@ -165,8 +170,17 @@ defmodule UXID.Registry do
 
   @doc """
   Registers an id under `key`. Requires `:prefix`; `:size`, `:schema`,
-  `:category`, `:validate`, and `:allow_uuid` are optional and fall back to the
-  registry defaults.
+  `:category`, `:validate`, `:allow_uuid`, and `:route` are optional and fall
+  back to the registry defaults.
+
+  Two further options carry no shape information:
+
+    * `:deterministic` - when `true`, the key is derived by contract and
+      `generate!/2` raises unless given `from:`. See `guides/deterministic.md`.
+    * `:legacy` - opaque app metadata (any term), surfaced on `all/0` so a
+      migration backlog lives in the registry rather than a moduledoc.
+
+  An unrecognized option is a compile error.
   """
   defmacro defid(key, opts \\ []) do
     quote bind_quoted: [key: key, opts: opts] do
@@ -176,7 +190,7 @@ defmodule UXID.Registry do
 
   @doc """
   Reserves a prefix so it participates in the uniqueness check but is never
-  generated — mirroring "identifiers are never reused". Accepts a string or atom.
+  generated - mirroring "identifiers are never reused". Accepts a string or atom.
   """
   defmacro retired(prefix) do
     quote bind_quoted: [prefix: prefix] do
@@ -186,7 +200,7 @@ defmodule UXID.Registry do
 
   # This macro emits the registry's whole public API as one quoted block, so its
   # cyclomatic count reflects the number of generated functions, not branching
-  # logic — the actual branching lives in the small runtime helpers below.
+  # logic - the actual branching lives in the small runtime helpers below.
   # credo:disable-for-next-line Credo.Check.Refactor.CyclomaticComplexity
   defmacro __before_compile__(env) do
     module = env.module
@@ -232,13 +246,14 @@ defmodule UXID.Registry do
       @doc "The registered keys, in declaration order."
       def keys(), do: unquote(Enum.map(entries, & &1.key))
 
-      @doc "Reserved (retired) prefixes — unique-checked but never generated."
+      @doc "Reserved (retired) prefixes - unique-checked but never generated."
       def reserved(), do: @uxid_reserved_data
 
       @doc """
-      A JSON-safe manifest of the registered ids — a list of maps with string
-      keys and scalar (`prefix`, `size`, `category`, `key`) values, `nil` where
-      unset. This is the cross-source single source of truth: emit it so a
+      A JSON-safe manifest of the registered ids - a list of maps with string
+      keys and scalar (`key`, `prefix`, `size`, `category`, `deterministic`)
+      values, `nil` where unset. This is the cross-source single source of truth:
+      emit it so a
       database function or a mobile/JS generator mints prefixes the same way the
       Elixir app does. Encode it with any JSON library, or use `manifest_json/0`.
       """
@@ -271,13 +286,30 @@ defmodule UXID.Registry do
       """
       def field_opts(key), do: UXID.Registry.field_opts_for(fetch!(key), @uxid_delimiter_str)
 
-      @doc "Generates a UXID for `key`. See `UXID.generate!/1`."
-      def generate!(key),
-        do: UXID.generate!(UXID.Registry.gen_opts(fetch!(key), @uxid_delimiter_str))
+      @doc """
+      Generates a UXID for `key`. See `UXID.generate!/1`.
 
-      @doc "Generates a UXID for `key`, wrapped in `{:ok, uxid}`."
-      def generate(key),
-        do: UXID.generate(UXID.Registry.gen_opts(fetch!(key), @uxid_delimiter_str))
+      `opts` are merged over the registry's, so a call site can pass anything the
+      entry does not own - most usefully `from:` for a deterministic
+      (name-based) ID:
+
+          MyApp.IDs.generate!(:faraday_export, from: phone)
+          MyApp.IDs.generate!(:share, monotonic: false)
+
+      `:prefix` and `:size` belong to the key and raise `ArgumentError` if
+      passed - the registry's contract is that a key determines both. The
+      intended override surface is `:from`, `:case`, `:monotonic`,
+      `:compact_time`, and `:rand_size`.
+      """
+      def generate!(key, opts \\ []),
+        do: UXID.generate!(UXID.Registry.gen_opts(fetch!(key), @uxid_delimiter_str, opts))
+
+      @doc """
+      Generates a UXID for `key`, wrapped in `{:ok, uxid}`. Takes the same
+      `opts` as `generate!/2`.
+      """
+      def generate(key, opts \\ []),
+        do: UXID.generate(UXID.Registry.gen_opts(fetch!(key), @uxid_delimiter_str, opts))
 
       @doc """
       The full registry entry for an ID string, or `nil` if its prefix is not
@@ -287,7 +319,7 @@ defmodule UXID.Registry do
       def resolve(id), do: UXID.Registry.resolve_id(@uxid_index, id, @uxid_delimiter_str)
 
       @doc """
-      Cheap prefix-only membership check for an ID string — the pre-filter for an
+      Cheap prefix-only membership check for an ID string - the pre-filter for an
       IDOR scan path. Does not validate the body.
       """
       def known?(id), do: UXID.Registry.known_id?(@uxid_index, id, @uxid_delimiter_str)
@@ -296,7 +328,7 @@ defmodule UXID.Registry do
       def key_for(id), do: UXID.Registry.field_of(resolve(id), :key)
 
       @doc """
-      The schema module for an ID string (or `nil`) — the prefix→schema map.
+      The schema module for an ID string (or `nil`) - the prefix→schema map.
       Resolves a compile-time `schema:` literal first, then the runtime routing
       table built from schema self-registration (see `verify!/1`).
       """
@@ -336,8 +368,8 @@ defmodule UXID.Registry do
       self-registration). Raises `ArgumentError` listing every problem, returns
       `:ok` otherwise.
 
-      Call from your top app's `start/2` so every boot — prod, dev, and CI's
-      `mix test` — verifies:
+      Call from your top app's `start/2` so every boot - prod, dev, and CI's
+      `mix test` - verifies:
 
           def start(_type, _args) do
             MyApp.IDs.verify!(otp_apps: [:my_app])
@@ -375,9 +407,50 @@ defmodule UXID.Registry do
     ]
   end
 
+  # Options a key owns: they are derived from the entry and a call site may not
+  # override them, or the minted ID would lie about its key.
+  @pinned_gen_opts [:prefix, :size]
+
   @doc false
-  def gen_opts(entry, delimiter),
-    do: [prefix: entry.prefix, size: entry.size, delimiter: delimiter]
+  def gen_opts(entry, delimiter, overrides \\ []) do
+    reject_pinned!(entry, overrides)
+
+    opts =
+      [prefix: entry.prefix, size: entry.size, delimiter: delimiter]
+      |> Keyword.merge(overrides)
+
+    require_from!(entry, opts)
+
+    opts
+  end
+
+  defp reject_pinned!(entry, overrides) do
+    case Enum.filter(@pinned_gen_opts, &Keyword.has_key?(overrides, &1)) do
+      [] ->
+        :ok
+
+      pinned ->
+        raise ArgumentError,
+              "#{inspect(pinned)} cannot be overridden when generating by key - " <>
+                "#{inspect(entry.key)} is registered with prefix #{inspect(entry.prefix)} " <>
+                "and size #{inspect(entry.size)}. Use UXID.generate!/1 directly if you " <>
+                "really need a one-off shape."
+    end
+  end
+
+  # A key declared `deterministic: true` is derived by contract, so minting it
+  # without `from:` would silently produce a second ID shape for one entity.
+  defp require_from!(%{deterministic: true, key: key}, opts) do
+    if is_nil(Keyword.get(opts, :from)) do
+      raise ArgumentError,
+            "key #{inspect(key)} is declared deterministic: true and must be minted with " <>
+              "from: - e.g. generate!(#{inspect(key)}, from: natural_key)"
+    end
+
+    :ok
+  end
+
+  defp require_from!(_entry, _opts), do: :ok
 
   @doc false
   def resolve_id(index, id, delimiter) when is_binary(id) do
@@ -427,7 +500,7 @@ defmodule UXID.Registry do
   end
 
   # Scans the given OTP apps for modules carrying the `UXID.Registered` marker,
-  # force-loading each so `function_exported?/3` sees it — that force-load is
+  # force-loading each so `function_exported?/3` sees it - that force-load is
   # what makes the table complete at boot even for otherwise-lazy modules.
   @doc false
   def collect_markers(apps) do
@@ -508,7 +581,7 @@ defmodule UXID.Registry do
     end
   end
 
-  @manifest_fields [:key, :prefix, :size, :category]
+  @manifest_fields [:key, :prefix, :size, :category, :deterministic]
 
   @doc false
   def manifest(entries) do
@@ -525,8 +598,11 @@ defmodule UXID.Registry do
   end
 
   # A registry field value rendered as a JSON-safe scalar: atoms become strings,
-  # nil stays nil (JSON null), strings pass through.
+  # nil stays nil (JSON null), booleans and strings pass through. The boolean
+  # clauses must precede the atom clause, which would otherwise stringify them.
   defp scalar(nil), do: nil
+  defp scalar(true), do: true
+  defp scalar(false), do: false
   defp scalar(value) when is_atom(value), do: Atom.to_string(value)
   defp scalar(value) when is_binary(value), do: value
 
@@ -540,6 +616,8 @@ defmodule UXID.Registry do
   end
 
   defp json_value(nil), do: "null"
+  defp json_value(true), do: "true"
+  defp json_value(false), do: "false"
   defp json_value(value) when is_binary(value), do: json_string(value)
 
   defp json_string(value), do: IO.iodata_to_binary([?", escape(value), ?"])
@@ -564,6 +642,8 @@ defmodule UXID.Registry do
       raise ArgumentError, "defid key must be an atom in #{inspect(module)}, got: #{inspect(key)}"
     end
 
+    validate_opt_names!(key, opts, module)
+
     prefix = Keyword.get(opts, :prefix)
 
     unless is_binary(prefix) do
@@ -585,8 +665,42 @@ defmodule UXID.Registry do
       # A key "must route" (verify!/1 fails if it resolves to no schema) when it
       # carries a compile-time `schema:` literal, or is explicitly opted in with
       # `route: true` so a self-registered schema is required to fill it.
-      route: Keyword.get(opts, :route, not is_nil(schema))
+      route: Keyword.get(opts, :route, not is_nil(schema)),
+      # Declares that the key is *always* derived: generate! by key requires
+      # from:. A requirement, not a permission - an undeclared key may still be
+      # minted deterministically.
+      deterministic: Keyword.get(opts, :deterministic, false),
+      # Opaque app metadata with no library behavior - somewhere to record "this
+      # key is deliberately still on an older scheme, retrofit deferred" so the
+      # backlog is visible in the registry rather than buried in a moduledoc.
+      legacy: Keyword.get(opts, :legacy)
     }
+  end
+
+  @defid_opts [
+    :prefix,
+    :size,
+    :schema,
+    :category,
+    :validate,
+    :allow_uuid,
+    :route,
+    :deterministic,
+    :legacy
+  ]
+
+  # A compile-time registry whose selling point is catching mistakes at compile
+  # time should not silently ignore a typo'd option.
+  defp validate_opt_names!(key, opts, module) do
+    case Keyword.keys(opts) -- @defid_opts do
+      [] ->
+        :ok
+
+      unknown ->
+        raise ArgumentError,
+              "unrecognized defid option(s) for #{inspect(key)} in #{inspect(module)}: " <>
+                "#{inspect(unknown)}. Recognized options: #{inspect(@defid_opts)}"
+    end
   end
 
   defp validate_delimiter!(module, delimiter) do

--- a/test/support/schemas.ex
+++ b/test/support/schemas.ex
@@ -2,7 +2,7 @@ defmodule UXID.TestSupport.Account do
   @moduledoc false
   use Ecto.Schema
 
-  # Draws every id option from the registry — the single source of truth. A
+  # Draws every id option from the registry - the single source of truth. A
   # conformance test then reflects over this schema to prove its prefix is
   # registered (see UXID.RegistryConformanceTest and guides/registry.md).
   @primary_key {:id, UXID, [autogenerate: true] ++ UXID.TestSupport.IDs.field_opts(:org)}

--- a/test/support/test_ids.ex
+++ b/test/support/test_ids.ex
@@ -27,7 +27,7 @@ defmodule UXID.TestSupport.IDs do
 end
 
 # A schema that self-registers under a routed registry key via the marker
-# mixin — the reference points down (schema names a key), never up.
+# mixin - the reference points down (schema names a key), never up.
 defmodule UXID.TestSupport.Widget do
   @moduledoc false
   use UXID.Registered, key: :widget
@@ -42,4 +42,16 @@ defmodule UXID.TestSupport.RoutedIDs do
 
   defid :widget, prefix: "wid", route: true
   defid :gadget, prefix: "gad", route: false
+end
+
+# A registry exercising the derived-key options: `:export` is always minted from
+# a natural key, `:enrichment` records a deferred migration off an older scheme,
+# and `:note` is an ordinary key for the contrast cases.
+defmodule UXID.TestSupport.DeterministicIDs do
+  @moduledoc false
+  use UXID.Registry, default_size: :medium
+
+  defid :export, prefix: "exp", deterministic: true
+  defid :enrichment, prefix: "enr", legacy: :uuid5_deferred
+  defid :note, prefix: "note"
 end

--- a/test/uxid/decoder_test.exs
+++ b/test/uxid/decoder_test.exs
@@ -1,5 +1,5 @@
 defmodule UXID.DecoderTest do
-  # async: false — a test here mutates global config (Application.put_env). ExUnit
+  # async: false - a test here mutates global config (Application.put_env). ExUnit
   # never runs a sync module concurrently with async ones, so this keeps that
   # global from bleeding into other tests mid-run.
   use ExUnit.Case, async: false

--- a/test/uxid/encoder_test.exs
+++ b/test/uxid/encoder_test.exs
@@ -1,5 +1,5 @@
 defmodule UXID.EncoderTest do
-  # async: false — several tests here mutate global config (Application.put_env
+  # async: false - several tests here mutate global config (Application.put_env
   # for :case, :min_size, :compact_small_times). ExUnit never runs a sync module
   # concurrently with async ones, so this keeps those globals from bleeding into
   # other tests mid-run.

--- a/test/uxid/monotonic_test.exs
+++ b/test/uxid/monotonic_test.exs
@@ -1,5 +1,5 @@
 defmodule UXID.MonotonicTest do
-  # async: false — the precedence tests mutate global config (Application.put_env
+  # async: false - the precedence tests mutate global config (Application.put_env
   # for :monotonic). ExUnit never runs a sync module concurrently with async ones,
   # so this keeps that global from bleeding into other tests mid-run.
   use ExUnit.Case, async: false
@@ -29,7 +29,7 @@ defmodule UXID.MonotonicTest do
 
     test "a same-ms burst is strictly increasing and unique" do
       # A high random seed can overflow the field within the burst, which spins
-      # the time forward 1ms and reseeds — those draws are a new run, not the same
+      # the time forward 1ms and reseeds - those draws are a new run, not the same
       # ms. Group by emitted time and assert the per-ms guarantee on each run.
       draws =
         for _ <- 1..100 do
@@ -113,7 +113,7 @@ defmodule UXID.MonotonicTest do
 
       assert :binary.decode_unsigned(a2) > :binary.decode_unsigned(a)
       # b lives under a separate key ({prefix, rand_size}), so a's advances leave
-      # it untouched — a fresh, correctly sized seed.
+      # it untouched - a fresh, correctly sized seed.
       assert byte_size(b) == 2
     end
 
@@ -165,7 +165,7 @@ defmodule UXID.MonotonicTest do
         end
 
       # The child starts its own sequence (a fresh seed), not a continuation of
-      # the parent's — so it does not land in the parent's forward step window.
+      # the parent's - so it does not land in the parent's forward step window.
       u1 = :binary.decode_unsigned(r1)
       refute :binary.decode_unsigned(child) in (u1 + 1)..(u1 + (1 <<< 16))
     end
@@ -181,14 +181,14 @@ defmodule UXID.MonotonicTest do
 
   # The emitted `{time, rand_int}` pair. The time matters because a same-ms burst
   # that overflows the field spins the time forward 1ms and reseeds (see
-  # UXID.Monotonic) — those draws belong to a new millisecond, not the same run.
+  # UXID.Monotonic) - those draws belong to a new millisecond, not the same run.
   defp rand_pair(opts) do
     {:ok, codec} = UXID.new(opts)
     {codec.time, :binary.decode_unsigned(codec.rand)}
   end
 
   # A first draw plus a second consecutive draw that stayed in the same emitted
-  # millisecond — a pure forward step, no overflow reseed. `t2` is the wall-clock
+  # millisecond - a pure forward step, no overflow reseed. `t2` is the wall-clock
   # handed to the second draw; pass `t2 < t1` to model a backward clock. A high
   # random seed occasionally overflows the field on the step, which the module
   # handles by spinning the time forward and reseeding; retry past that rare case
@@ -206,7 +206,7 @@ defmodule UXID.MonotonicTest do
   # Decides whether `opts` yields a monotonic sequence. A monotonic burst is
   # strictly increasing and unique *within a millisecond*; a random one shares one
   # ms and is sorted only by chance (~1/n!). A 20-draw burst makes false positives
-  # ~1/20! — effectively zero. We group draws by their emitted ms and check each
+  # ~1/20! - effectively zero. We group draws by their emitted ms and check each
   # run on its own: a high random seed can overflow the field mid-burst, which
   # starts a fresh run in the next ms, so comparing the raw ints across that
   # boundary would spuriously fail.
@@ -253,7 +253,7 @@ defmodule UXID.MonotonicTest do
       {:ok, c2} = UXID.new(size: :small, time: 1_700_000_199_995, monotonic: true)
 
       # The backward clock never emits a smaller time: normally it keeps c1's time,
-      # and in the rare case the field overflows on the step it spins 1ms forward —
+      # and in the rare case the field overflows on the step it spins 1ms forward -
       # never backward. (Exact keep-the-last-time is covered at the Monotonic unit
       # level.) The encoded ID still strictly increases either way.
       assert c2.time >= c1.time

--- a/test/uxid/registry_test.exs
+++ b/test/uxid/registry_test.exs
@@ -3,7 +3,7 @@ defmodule UXID.RegistryTest do
 
   doctest UXID.Registry
 
-  alias UXID.TestSupport.{Contact, IDs, Org}
+  alias UXID.TestSupport.{Contact, DeterministicIDs, IDs, Org}
 
   describe "by-key API" do
     test "prefix/1, size/1, schema/1, category/1" do
@@ -71,7 +71,14 @@ defmodule UXID.RegistryTest do
 
     test "manifest/0 renders unset size/category as nil" do
       lead = Enum.find(IDs.manifest(), &(&1["key"] == "lead"))
-      assert lead == %{"key" => "lead", "prefix" => "lead", "size" => "medium", "category" => nil}
+
+      assert lead == %{
+               "key" => "lead",
+               "prefix" => "lead",
+               "size" => "medium",
+               "category" => nil,
+               "deterministic" => false
+             }
     end
 
     test "manifest_json/0 emits deterministic JSON with nulls" do
@@ -81,9 +88,22 @@ defmodule UXID.RegistryTest do
       assert String.ends_with?(json, "]")
 
       assert json =~
-               ~s({"key":"org","prefix":"org","size":"medium","category":"account"})
+               ~s({"key":"org","prefix":"org","size":"medium","category":"account","deterministic":false})
 
-      assert json =~ ~s({"key":"lead","prefix":"lead","size":"medium","category":null})
+      assert json =~
+               ~s({"key":"lead","prefix":"lead","size":"medium","category":null,"deterministic":false})
+    end
+
+    test "manifest/0 carries the deterministic flag as a real boolean" do
+      export = Enum.find(DeterministicIDs.manifest(), &(&1["key"] == "export"))
+      assert export["deterministic"] == true
+    end
+
+    test "manifest_json/0 emits deterministic as an unquoted JSON bool" do
+      json = DeterministicIDs.manifest_json()
+
+      assert json =~ ~s("deterministic":true)
+      refute json =~ ~s("deterministic":"true")
     end
   end
 
@@ -181,6 +201,111 @@ defmodule UXID.RegistryTest do
         end
         """)
       end
+    end
+
+    test "rejects an unrecognized defid option" do
+      assert_raise ArgumentError, ~r/unrecognized defid option\(s\) for :a.*\[:validat\]/s, fn ->
+        Code.compile_string("""
+        defmodule Sample.TypoOpt do
+          use UXID.Registry
+          defid :a, prefix: "aa", validat: false
+        end
+        """)
+      end
+    end
+  end
+
+  describe "generate!/2 opts passthrough" do
+    test "merges caller opts over the registry's" do
+      assert {:ok, "org_" <> body} = IDs.generate(:org, case: :upper)
+      assert String.upcase(body) == body
+    end
+
+    test "arity-1 calls are unchanged" do
+      assert String.starts_with?(IDs.generate!(:org), "org_")
+    end
+
+    test "from: mints a deterministic id by key" do
+      id = IDs.generate!(:org, from: "+15555550123")
+
+      assert id == IDs.generate!(:org, from: "+15555550123")
+      assert UXID.deterministic?(id)
+      assert String.starts_with?(id, "org_")
+    end
+
+    test "a deterministic by-key id carries the registry's prefix and size" do
+      id = IDs.generate!(:in_ref, from: "abc")
+
+      assert {:ok, decoded} = UXID.decode(id)
+      assert decoded.prefix == "in_ref"
+      assert decoded.size == :small
+    end
+
+    test "rejects an override of prefix or size" do
+      for opt <- [[prefix: "nope"], [size: :large]] do
+        assert_raise ArgumentError, ~r/cannot be overridden when generating by key/, fn ->
+          IDs.generate!(:org, opt)
+        end
+      end
+    end
+
+    test "the pinned-opt check also guards generate/2" do
+      assert_raise ArgumentError, ~r/cannot be overridden/, fn ->
+        IDs.generate(:org, prefix: "nope")
+      end
+    end
+  end
+
+  describe "deterministic: true keys" do
+    test "raise when minted without from:" do
+      assert_raise ArgumentError, ~r/:export is declared deterministic: true/, fn ->
+        DeterministicIDs.generate!(:export)
+      end
+
+      assert_raise ArgumentError, ~r/must be minted with from:/, fn ->
+        DeterministicIDs.generate(:export)
+      end
+    end
+
+    test "mint with from:" do
+      id = DeterministicIDs.generate!(:export, from: "natural-key")
+
+      assert id == DeterministicIDs.generate!(:export, from: "natural-key")
+      assert UXID.deterministic?(id)
+      assert String.starts_with?(id, "exp_")
+    end
+
+    test "an explicit nil from: is not enough" do
+      assert_raise ArgumentError, ~r/must be minted with from:/, fn ->
+        DeterministicIDs.generate!(:export, from: nil)
+      end
+    end
+
+    test "the flag is a requirement, not a permission" do
+      # An undeclared key may still be minted deterministically...
+      assert UXID.deterministic?(DeterministicIDs.generate!(:note, from: "x"))
+      # ...and is unaffected when minted normally.
+      refute UXID.deterministic?(DeterministicIDs.generate!(:note))
+    end
+
+    test "the flag is surfaced on all/0 for app-side conformance tests" do
+      by_key = Map.new(DeterministicIDs.all(), &{&1.key, &1})
+
+      assert by_key[:export].deterministic
+      refute by_key[:note].deterministic
+    end
+  end
+
+  describe "legacy: metadata" do
+    test "round-trips onto the entry and all/0" do
+      by_key = Map.new(DeterministicIDs.all(), &{&1.key, &1})
+
+      assert by_key[:enrichment].legacy == :uuid5_deferred
+      assert by_key[:note].legacy == nil
+    end
+
+    test "carries no behavior - the key mints normally" do
+      assert String.starts_with?(DeterministicIDs.generate!(:enrichment), "enr_")
     end
   end
 end


### PR DESCRIPTION
## Summary

2.7.0 shipped `from:` on the plain API, and its design note claimed the option "composes with the registry's by-key `generate!/1` for free". It did not: the generated `generate!/1` was arity-1 and dropped caller options, so a registry user had to drop to the plain API and hand-assemble prefix/size.

- Generated `generate!/2` and `generate/2` merge caller options over the registry's, so `MyApp.IDs.generate!(:export, from: natural_key)` mints deterministically by key. Existing arity-1 calls are unchanged.
- `:prefix` and `:size` raise if overridden - the registry's contract is that a key determines its shape. Override surface is `:from`, `:case`, `:monotonic`, `:compact_time`, `:rand_size`.
- `defid :export, deterministic: true` declares a key as always derived: minting it without `from:` raises, so one call site cannot derive while another mints randomly. A requirement, not a permission - an undeclared key may still be minted with `from:`.
- `deterministic` joins the JSON manifest as a real boolean, so another generator knows which scheme a key uses. Needed boolean clauses on `scalar/1` and `json_value/1`, which had only ever seen strings, atoms, and nil.
- `legacy:` records opaque app metadata (no library behavior) so a deferred-migration backlog lives in the registry, not a moduledoc.
- An unrecognized `defid` option is now a compile error rather than being silently ignored. Technically breaking, hence 2.8.0 rather than 2.7.1.

The declaration cannot reach Ecto's `autogenerate`, which has no per-row input, and `field_opts/1` cannot raise because it also serves validate-only foreign-key fields. Both guides state that a deterministic key must be minted in a changeset instead.

Also replaces typographic punctuation (em/en dashes) with plain-keyboard equivalents throughout the docs, and links README guides to HexDocs so they resolve correctly from hex.pm.

## Test plan

- [x] `mix test`